### PR TITLE
Feature/209  カード情報一括登録画面の改修

### DIFF
--- a/app/Facades/APIHand.php
+++ b/app/Facades/APIHand.php
@@ -1,0 +1,21 @@
+<?php
+namespace App\Facades;
+
+use Illuminate\Support\Facades\Facade;
+
+/**
+ * ExServiceクラス用のFacadeクラス
+ * 処理自体はExpansionServiceクラスを参照。
+ */
+class APIHand extends Facade {
+
+    /**
+     * Get the registered name of the component.
+     *
+     * @return string
+     */
+    protected static function getFacadeAccessor()
+    {
+        return 'APIHand';
+    }
+}

--- a/app/Http/Controllers/ArrivalController.php
+++ b/app/Http/Controllers/ArrivalController.php
@@ -19,6 +19,7 @@ use App\Services\Stock\ArrivalParams;
 use App\Services\Stock\ArrivalLogService;
 use App\Services\Constant\SearchConstant as Con;
 use App\Services\Constant\ArrivalConstant as ACon;
+use App\Facades\APIHand;
 
 /**
  * 入荷手続きAPI
@@ -41,7 +42,7 @@ class ArrivalController extends Controller {
         $details = $request->only([Con::CARD_NAME, ACon::ARRIVAL_DATE, Con::VENDOR_TYPE_ID]);
         $search = fn($details) => $this->service->filtering($details);  // 検索処理
         $transformer = fn($results) => ArrivalLogResource::collection($results); // 変換処理
-        return $this->handleSearch($details, $search, $transformer);
+        return APIHand::handleSearch($details, $search, $transformer);
     }
 
     /**
@@ -54,21 +55,9 @@ class ArrivalController extends Controller {
         $details = $request->only([Con::CARD_NAME, Con::START_DATE, Con::END_DATE]);
         $search = fn($details) => $this->service->fetch($details);  // 検索処理
         $transformer = fn($results) => ArrivalGroupingLogResource::collection($results); // 変換処理
-        return $this->handleSearch($details, $search, $transformer);
-
+        return APIHand::handleSearch($details, $search, $transformer);
     }
 
-    private function handleSearch(array $details, callable $fetchMethod, ?callable $transformer) {
-        logger()->info('Start to search arrival log', $details);
-        $results = $fetchMethod($details);
-        if ($results->isEmpty()) {
-            logger()->info('No Result');
-            throw new NoContentException();
-        }
-        $count = $results->count();
-        logger()->info("End to search $count arrival log");
-        return response($transformer($results), Response::HTTP_OK);
-    }
 
     /**
      * 入荷情報と在庫情報を登録する。

--- a/app/Http/Controllers/Handler/APIHandler.php
+++ b/app/Http/Controllers/Handler/APIHandler.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Controllers\Handler;
+
+use App\Exceptions\api\NoContentException;
+use Illuminate\Http\Response;
+
+class APIHandler {
+
+    public function handleSearch(array $details, callable $fetchMethod, ?callable $transformer) {
+        logger()->info('Start to search condition:', $details);
+        $results = $fetchMethod($details);
+        if ($results->isEmpty()) {
+            logger()->info('No Result');
+            throw new NoContentException();
+        }
+        $count = $results->count();
+        logger()->info("End to search Result Count:$count");
+        return response($transformer($results), Response::HTTP_OK);
+    }
+}

--- a/app/Http/Controllers/Notion/ExpansionController.php
+++ b/app/Http/Controllers/Notion/ExpansionController.php
@@ -27,5 +27,9 @@ class ExpansionController extends Controller
         $json = ExpansionResource::collection($result);
         return response()->json($json, Response::HTTP_OK);
     }
+
+    public function show($id) {
+
+    }
 }
 ?>

--- a/app/Http/Controllers/PromotypeController.php
+++ b/app/Http/Controllers/PromotypeController.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Facades\APIHand;
+use App\Facades\Promo;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\PromoSearchRequest;
+use Illuminate\Http\Request;
+use App\Services\Constant\StockpileHeader as Header;
+use App\Services\PromoService;
+
+/**
+ * 特別版に関するControllerクラス
+ */
+class PromotypeController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index(PromoSearchRequest $request)
+    {
+        $details = $request->only([Header::SETCODE]);
+        $search = fn($details) => Promo::fetch($details);  // 検索処理
+        $transformer = fn($results) => $results; // 変換処理
+        return APIHand::handleSearch($details, $search, $transformer);
+
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(string $id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, string $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(string $id)
+    {
+        //
+    }
+}

--- a/app/Http/Requests/PromoSearchRequest.php
+++ b/app/Http/Requests/PromoSearchRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Rules\Halfsize;
+use Illuminate\Foundation\Http\FormRequest;
+use App\Services\Constant\StockpileHeader as Header;
+
+
+class PromoSearchRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            Header::SETCODE => [['required', 'regex:/^[a-zA-Z0-9]+$/']]
+        ];
+    }
+}

--- a/app/Http/Resources/ExpDBResource.php
+++ b/app/Http/Resources/ExpDBResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Resources;
 
+use App\Libs\CarbonFormatUtil;
 use Illuminate\Http\Resources\Json\JsonResource;
 
 class ExpDBResource extends JsonResource
@@ -17,6 +18,7 @@ class ExpDBResource extends JsonResource
         return [
                 'name' => $this->name,
                 'attr' => $this->attr,
+                'release_date' => CarbonFormatUtil::toDateString($this->release_date)
             ];
     }
 }

--- a/app/Http/Resources/ExpDBResource.php
+++ b/app/Http/Resources/ExpDBResource.php
@@ -16,6 +16,7 @@ class ExpDBResource extends JsonResource
     public function toArray($request)
     {
         return [
+                'notion_id' => $this->notion_id,
                 'name' => $this->name,
                 'attr' => $this->attr,
                 'release_date' => CarbonFormatUtil::toDateString($this->release_date)

--- a/app/Models/Expansion.php
+++ b/app/Models/Expansion.php
@@ -16,7 +16,7 @@ class Expansion extends Model
 
     protected $keyType = 'string';
 
-    protected $fillable = ['notion_id', 'base_id', 'name', 'attr', 'release_date'];
+    protected $fillable = ['id', 'notion_id', 'name', 'attr', 'release_date'];
 
     public function cardinfo()
     {
@@ -39,6 +39,11 @@ class Expansion extends Model
      */
     public static function findByNotionId(string $notionId) {
         return Expansion::where('notion_id', $notionId)->first();
+    }
+
+    public static function findBySetCode(string $setCode) {
+        return Expansion::where('attr', $setCode)->first();
+
     }
 
 }

--- a/app/Models/Promotype.php
+++ b/app/Models/Promotype.php
@@ -48,7 +48,7 @@ class Promotype extends Model
         $result = $query->join('expansion as e', function($join) {
                                     $join->on('p.exp_id', 'e.notion_id');
                                 })->whereIn('e.attr', $condition)
-                                ->orderBy('e.release_date', 'desc')->orderBy('p.id')->get();
+                                ->orderBy('e.release_date')->orderBy('p.id')->get();
         return $result;
     }
 }

--- a/app/Models/Promotype.php
+++ b/app/Models/Promotype.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
@@ -34,5 +35,20 @@ class Promotype extends Model
         return Promotype::where('name', $name)->first();
     }
 
-
+    /**
+     * エキスパンション略称に該当する特別版を取得する。
+     *
+     * @param string $setcode
+     * @return Collection
+     */
+    public static function findBySetCode(string $setcode) {
+        $condition = ['COM', $setcode];
+        $columns = ['p.id', 'p.attr', 'p.name', 'e.attr as setcode'];
+        $query = DB::table('promotype as p')->select($columns);
+        $result = $query->join('expansion as e', function($join) {
+                                    $join->on('p.exp_id', 'e.notion_id');
+                                })->whereIn('e.attr', $condition)
+                                ->orderBy('e.release_date', 'desc')->orderBy('p.id')->get();
+        return $result;
+    }
 }

--- a/app/Providers/APIHandlerProvider.php
+++ b/app/Providers/APIHandlerProvider.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+class APIHandlerProvider extends ServiceProvider
+{
+    /**
+     * Register services.
+     */
+    public function register(): void
+    {
+        $this->app->bind('APIHand', 'App\Http\Controllers\Handler\APIHandler');
+    }
+
+    /**
+     * Bootstrap services.
+     */
+    public function boot(): void
+    {
+        //
+    }
+}

--- a/app/Rules/Halfsize.php
+++ b/app/Rules/Halfsize.php
@@ -22,14 +22,4 @@ class Halfsize implements ValidationRule
             $fail('validation.halfsize')->translate();
         }
      }
-
-    // /**
-    //  * Get the validation error message.
-    //  *
-    //  * @return string
-    //  */
-    // public function message()
-    // {
-    //     return trans('validation.halfsize');
-    // }
 }

--- a/app/Services/ExpansionService.php
+++ b/app/Services/ExpansionService.php
@@ -9,14 +9,21 @@ use App\Models\notion\NotionExp;
 use App\Services\ScryfallService;
 use FiveamCode\LaravelNotionApi\Entities\Page;
 use Carbon\Carbon;
-
+use Illuminate\Support\Facades\DB;
 
 /**
- * エキスパンション一覧を操作するクラス
+ * エキスパンションを操作するクラス
  */
 class ExpansionService {
+    private $repo;
     public function __construct() {
         $this->repo = new ExpansionRepository();
+    }
+
+    public function fetch(string $query) {
+        $columns = ['id', 'notion_id', 'name', 'attr', 'release_date'];
+        $list = Expansion::where('attr', 'like', '%'.$query.'%')->limit(5)->get();
+        return $list;
     }
 
     public function findAll() {
@@ -71,12 +78,12 @@ class ExpansionService {
      */
     public function storeByScryfall(string $setcode, string $format) {
             // エキスパンション登録
-            $contents = \ScryfallServ::findSet($setcode);
+            $contents = \App\Facades\ScryfallServ::findSet($setcode);
             $block = MtgJsonUtil::hasKey('block', $contents) ? $contents['block'] : 'その他';
             $details = ['attr' => strtoupper($setcode), 'name' => $contents['name'],
                                     'block' => $block, 'format' => $format,
                                     'release_date' => $contents['released_at']];
-            \ExService::store($details);
+            $this->store($details);
 
     }
     /**

--- a/app/Services/PromoService.php
+++ b/app/Services/PromoService.php
@@ -3,7 +3,10 @@ namespace App\Services;
 
 use App\Exceptions\NoPromoTypeException;
 use App\Models\Promotype;
+use App\Services\Constant\StockpileHeader;
 use app\Services\json\AbstractCard;
+
+use function PHPUnit\Framework\isEmpty;
 
 /**
  * 特別版カードの仕様を特定するクラス
@@ -17,5 +20,23 @@ class PromoService {
                 throw new NoPromoTypeException($cardtype->getJson()['name'], $cardtype->number(), $promoValue);
         }
         return $promo->name;
+    }
+
+    /**
+     * 入力された条件を元に検索する。
+     *
+     * @param array $condition
+     * @return array
+     */
+    public function fetch(array $condition) {
+        $setcode = $condition[StockpileHeader::SETCODE];
+        $result = Promotype::findBySetCode($setcode);
+        $filtered = $result->filter(function($r) use ($setcode) {
+            return $r->setcode == $setcode;
+        });
+        if ($filtered->isEmpty()) {
+            return $filtered;
+        }
+        return $result;
     }
 }

--- a/config/app.php
+++ b/config/app.php
@@ -210,7 +210,8 @@ return [
         App\Providers\CardBoardProvider::class,
         App\Providers\StockpileServiceProvider::class,
         App\Providers\WisdomServProvider::class,
-        App\Providers\ScryfallProvider::class
+        App\Providers\ScryfallProvider::class,
+        App\Providers\APIHandlerProvider::class
     ],
 
     /*

--- a/database/migrations/2025_04_04_100613_add_column_promotype.php
+++ b/database/migrations/2025_04_04_100613_add_column_promotype.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('promotype', function (Blueprint $table) {
+            $table->string('exp_id')->default('c8f3a2b1-74e9-4d2f-b3a7-9e0f1c5d6a3b');
+            // カラムの外部キー制約追加
+            $table->foreign('exp_id')->references('notion_id')->on('expansion')->OnDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('promotype', function (Blueprint $table) {
+            // 外部キー制約の削除
+            $table->dropForeign('expantion_exp_id_foreign');
+            $table->dropColumn('exp_id');
+        });
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -20,6 +20,7 @@ class DatabaseSeeder extends Seeder
     public function run()
     {
         logger()->info('マスタデータ登録開始');
+        $this->call(ExpansionSeeder::class);
         $this->call(MainColorSeeder::class);
         $this->call(ShippingSeeder::class);
         $this->call(PromotypeSeeder::class);

--- a/database/seeders/ExpansionSeeder.php
+++ b/database/seeders/ExpansionSeeder.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Expansion;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class ExpansionSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        Expansion::create(['attr' => 'COM', 'name' => '共通エキスパンション',
+             'notion_id' => 'c8f3a2b1-74e9-4d2f-b3a7-9e0f1c5d6a3b', 'release_date' => '1970-01-01']);
+    }
+}

--- a/database/seeders/PromotypeSeeder.php
+++ b/database/seeders/PromotypeSeeder.php
@@ -2,6 +2,7 @@
 
 namespace Database\Seeders;
 
+use App\Models\Expansion;
 use App\Models\Promotype;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
@@ -17,48 +18,81 @@ class PromotypeSeeder extends Seeder
     public function run()
     {
         DB::table('promotype')->truncate();
-        Promotype::create(['attr' => 'jpwalker', 'name' => '絵違い']);
-        Promotype::create(['attr' => 'boosterfun', 'name' => 'ブースターファン']);
-        Promotype::create(['attr' => 'draft', 'name' => '']);
-        Promotype::create(['attr' => 'buyabox', 'name' => 'BOXプロモ特典']);
-        Promotype::create(['attr' => 'textured', 'name' => 'テクスチャー']);
-        Promotype::create(['attr' => 'bundle', 'name' => 'バンドル']);
-        Promotype::create(['attr' => 'showcase', 'name' => 'ショーケース']);
-        Promotype::create(['attr' => 'neonink', 'name' => 'ネオンインク']);
-        Promotype::create(['attr' => 'themepack', 'name' => 'テーマブースター限定']);
-        Promotype::create(['attr' => 'oilslick', 'name' => 'ボーダレス「胆液」ショーケース']);
-        Promotype::create(['attr' => 'concept', 'name' => 'コンセプトアート']);
-        Promotype::create(['attr' => 'stepandcompleat', 'name' => 'S&C']);
-        Promotype::create(['attr' => 'halofoil', 'name' => 'ハロー・Foil']);
-        Promotype::create(['attr' => 'intropack', 'name' => 'エントリーセット']);
-        Promotype::create(['attr' => 'brawldeck', 'name' => 'ブロールデッキ']);
-        Promotype::create(['attr' => 'fullart', 'name' => 'フルアート']);
-        Promotype::create(['attr' => 'gameday', 'name' => 'ゲームデー']);
-        Promotype::create(['attr' => 'datestamped', 'name' => '日付入りプロモカード']);
-        Promotype::create(['attr' => 'tourney', 'name' => 'トーナメント景品']);
-        Promotype::create(['attr' => 'jpainting', 'name' => '日本画ミスティカルアーカイブ']);
-        Promotype::create(['attr' => 'setpromo', 'name' => 'プレリリース']);
-        Promotype::create(['attr' => 'stamped', 'name' => 'プレリリース']);
-        Promotype::create(['attr' => 'borderless', 'name' => 'ボーダレス']);
-        Promotype::create(['attr' => 'bringafriend', 'name' => 'Bring-a-Friend']);
-        Promotype::create(['attr' => 'textless', 'name' => 'テキストレス・フルアート']);
-        Promotype::create(['attr' => 'adventure', 'name' => 'おとぎ話']);
-        Promotype::create(['attr' => 'anime', 'name' => 'アニメ・ボーダレス']);
-        Promotype::create(['attr' => 'phoilslick', 'name' => 'ファイレクシア語「胆液」']);
-        Promotype::create(['attr' => 'oilslickshowcase', 'name' => 'ショーケース「胆液」']);
-        Promotype::create(['attr' => 'boxtopper', 'name' => 'ボックストッパー']);
-        Promotype::create(['attr' => 'magnified', 'name' => '「拡大鏡」ショーケース']);
-        Promotype::create(['attr' => 'dossier', 'name' => '「事件簿」ショーケース']);
-        Promotype::create(['attr' => 'ravnicacity', 'name' => '大都市ラヴニカ']);
-        Promotype::create(['attr' => 'profiles', 'name' => '「プロファイル」ボーダーレス']);
-        Promotype::create(['attr' => 'flamebreak', 'name' => '「フレームブレイク」ボーダーレス']);
-        Promotype::create(['attr' => 'oldframe', 'name' => '旧枠']);
-        Promotype::create(['attr' => 'doubleexposure', 'name' => '「二重露光」ショーケース']);
-        Promotype::create(['attr' => 'paranormal', 'name' => '「超常」フレーム']);
-        Promotype::create(['attr' => 'mirror', 'name' => '「鏡の怪物」ボーダーレス']);
-        Promotype::create(['attr' => 'maxspeed', 'name' => '「最大出力」ボーダーレス']);
-        Promotype::create(['attr' => 'badassrider', 'name' => '「ワルなライダー」ボーダーレス']);
-        Promotype::create(['attr' => 'graffgiant', 'name' => '「グラフィティ・ジャイアント」ボーダーレス']);
-        Promotype::create(['attr' => 'firstplacefoil', 'name' => 'ファーストプレイス・Foil']);
+        
+        $exp_id = 'exp_id';
+        
+        // 共通
+        $com = Expansion::findBySetCode('COM');
+        // WAR
+        $war = Expansion::findBySetCode('WAR');
+        // NEO
+        $neo = Expansion::findBySetCode('NEO');
+        // MOM
+        $mom = Expansion::findBySetCode('MOM');
+        // AER
+        $aer = Expansion::findBySetCode('AER');
+        // ELD
+        $eld = Expansion::findBySetCode('ELD');
+        // STX
+        $stx = Expansion::findBySetCode('STX');      
+        // SCH(Store Championship)
+        $sch = Expansion::findBySetCode('SCH');
+        // WOE
+        $woe = Expansion::findBySetCode('WOE');
+        
+        // ONE
+        $one = Expansion::findBySetCode('ONE');
+        // MKM
+        $mkm = Expansion::findBySetCode('MKM');
+        // MH3
+        $mh3 = Expansion::findBySetCode('MH3');
+        // DSK
+        $dsk = Expansion::findBySetCode('DSK');
+        // DFT
+        $dft = Expansion::findBySetCode('DFT');
+        $items = [
+            ['attr' => 'draft', 'name' => '', $exp_id => $com->notion_id],
+            ['attr' => 'showcase', 'name' => 'ショーケース', $exp_id => $com->notion_id],
+            ['attr' => 'buyabox', 'name' => 'BOXプロモ特典', $exp_id => $com->notion_id],
+            ['attr' => 'boosterfun', 'name' => 'ブースターファン', $exp_id => $com->notion_id],
+            ['attr' => 'fullart', 'name' => 'フルアート', $exp_id => $com->notion_id],
+            ['attr' => 'boxtopper', 'name' => 'ボックストッパー', $exp_id => $com->notion_id],
+            ['attr' => 'borderless', 'name' => 'ボーダーレス', $exp_id => $com->notion_id],
+            ['attr' => 'bundle', 'name' => 'バンドル', $exp_id => $com->notion_id],
+            ['attr' => 'tourney', 'name' => 'トーナメント景品', $exp_id => $com->notion_id],
+            ['attr' => 'stamped', 'name' => 'プレリリース', $exp_id => $com->notion_id],
+            ['attr' => 'jpwalker', 'name' => '絵違い', $exp_id => $war->notion_id],
+            ['attr' => 'neonink', 'name' => 'ネオンインク', $exp_id => $neo->notion_id],
+            ['attr' => 'halofoil', 'name' => 'ハロー・Foil', $exp_id => $mom->notion_id],
+            ['attr' => 'intropack', 'name' => 'エントリーセット', $exp_id => $aer->notion_id],
+            ['attr' => 'brawldeck', 'name' => 'ブロールデッキ', $exp_id => $eld->notion_id],
+            ['attr' => 'jpainting', 'name' => '日本画ミスティカルアーカイブ', $exp_id => $stx->notion_id],
+            ['attr' => 'textless', 'name' => 'テキストレス・フルアート', $exp_id => $sch->notion_id],
+            ['attr' => 'bringafriend', 'name' => 'Bring-a-Friend', $exp_id => $sch->notion_id],
+            ['attr' => 'adventure', 'name' => 'おとぎ話', $exp_id => $woe->notion_id],
+            ['attr' => 'anime', 'name' => 'アニメ・ボーダーレス', $exp_id => $woe->notion_id],
+            ['attr' => 'phoilslick', 'name' => 'ファイレクシア語「胆液」', $exp_id => $one->notion_id],
+            ['attr' => 'oilslickshowcase', 'name' => 'ショーケース「胆液」', $exp_id => $one->notion_id],
+            ['attr' => 'oilslick', 'name' => 'ボーダレス「胆液」ショーケース', $exp_id => $one->notion_id],
+            ['attr' => 'stepandcompleat', 'name' => 'S&C', $exp_id => $one->notion_id],
+            ['attr' => 'concept', 'name' => 'コンセプトアート', $exp_id => $one->notion_id],
+            ['attr' => 'magnified', 'name' => '「拡大鏡」ショーケース', $exp_id => $mkm->notion_id],
+            ['attr' => 'dossier', 'name' => '「事件簿」ショーケース', $exp_id => $mkm->notion_id],
+            ['attr' => 'ravnicacity', 'name' => '大都市ラヴニカ', $exp_id => $mkm->notion_id],
+            ['attr' => 'profiles', 'name' => '「プロファイル」ボーダーレス', $exp_id => $mkm->notion_id],
+            ['attr' => 'flamebreak', 'name' => '「フレームブレイク」ボーダーレス', $exp_id => $mh3->notion_id],
+            ['attr' => 'oldframe', 'name' => '旧枠', $exp_id => $mh3->notion_id],
+            ['attr' => 'doubleexposure', 'name' => '「二重露光」ショーケース', $exp_id => $dsk->notion_id],
+            ['attr' => 'paranormal', 'name' => '「超常」フレーム', $exp_id => $dsk->notion_id],
+            ['attr' => 'mirror', 'name' => '「鏡の怪物」ボーダーレス', $exp_id => $dsk->notion_id],
+            ['attr' => 'maxspeed', 'name' => '「最大出力」ボーダーレス', $exp_id => $dft->notion_id],
+            ['attr' => 'badassrider', 'name' => '「ワルなライダー」ボーダーレス', $exp_id => $dft->notion_id],
+            ['attr' => 'graffgiant', 'name' => '「グラフィティ・ジャイアント」ボーダーレス', $exp_id => $dft->notion_id],
+            ['attr' => 'firstplacefoil', 'name' => 'ファーストプレイス・Foil', $exp_id => $dft->notion_id]
+        ]; 
+
+        foreach($items as $i ){
+            Promotype::create($i);
+        }
     }
 }

--- a/database/seeders/TestExpansionSeeder.php
+++ b/database/seeders/TestExpansionSeeder.php
@@ -35,5 +35,11 @@ class TestExpansionSeeder extends Seeder
         Expansion::create(['attr' => 'SPG', 'name' => 'スペシャルゲスト', 'notion_id' => 'xxxxssss-xxxxxd', 'release_date' => '2023-02-09']);
         Expansion::create(['attr' => 'MH3', 'name' => 'モダンホライゾン3', 'notion_id' => 'xxxxssss-xxxxxe', 'release_date' => '2024-06-14']);
         Expansion::create(['attr' => 'DSK', 'name' => 'ダスクモーン：戦慄の館', 'notion_id' => '132258ea-f797-4913-b107-60d6b2c0505c', 'release_date' => '2024-09-27']);
+        Expansion::create(['attr' => 'DFT', 'name' => '霊気走破', 'notion_id' => 'b6e4f2a2-93c8-489c-b1f0-2d7c9azb5f8b', 'release_date' => '2025-02-23']);
+
+        Expansion::create(['attr' => 'AER', 'name' => '霊気紛争', 'notion_id' => 'd1a7b3c9-82f4-4e1a-b5d2-90c6e8f7a4bd', 'release_date' => '2017-01-20']);
+        Expansion::create(['attr' => 'ELD', 'name' => 'エルドレインの王権', 'notion_id' => 'f3c9e1d4-6a2b-47d8-a0c3-b7e5d2f6c8a1', 'release_date' => '2019-10-04']);
+        Expansion::create(['attr' => 'STX', 'name' => 'ストリクスヘイヴン：魔法学院', 'notion_id' => 'b6e4f2a1-93c8-489d-b1f0-2d7c9a3e5f8b', 'release_date' => '2021-04-23']);
+        Expansion::create(['attr' => 'SCH', 'name' => 'Store Championship', 'notion_id' => 'a9c0d3f2-71b5-403e-b6a8-c1e4f7d2a9c3', 'release_date' => '2022-07-09']);
     }
 }

--- a/resources/js/component/App.vue
+++ b/resources/js/component/App.vue
@@ -18,15 +18,7 @@ import Loading from "vue-loading-overlay";
                     :class="{
                         active: $route.path === '/config/expansion',
                     }"
-                    >エキスパンション一覧</router-link
-                >
-                <router-link
-                    to="/config/cardinfo/csv"
-                    class="item"
-                    :class="{
-                        active: $route.path === '/config/cardinfo/csv',
-                    }"
-                    >カード情報マスタ登録</router-link
+                    ><i class="cogs icon"></i>マスタ設定</router-link
                 >
             </div>
         </div>

--- a/resources/js/pages/component/PromoDropdown.vue
+++ b/resources/js/pages/component/PromoDropdown.vue
@@ -1,0 +1,23 @@
+<script  setup>
+import { onMounted, reactive } from "vue";
+import axios from "axios";
+const name = defineModel("name");
+const setcode = defineModel("setcode");
+const list = reactive([]);
+onMounted(async() => {
+        // 特別版一覧を取得
+        await axios
+            .get('/api/promo/' + '?setcode=' + setcode.value)
+            .then((response) => {
+                list.value = response.data;
+            })
+            .catch((e) => {
+                console.error(e);
+            })    
+});
+</script>
+<template>
+<select v-model="name" class="mr-1 ui dropdown">
+    <option v-for="t in list.value" :key="t.id" :value="t.name">{{t.name }}</option>
+</select>
+</template>

--- a/resources/js/pages/config/CardInfoCsvPage.vue
+++ b/resources/js/pages/config/CardInfoCsvPage.vue
@@ -29,6 +29,7 @@
             {{ filename }}
         </div>
     </article>
+    <promo v-model:name="name" v-model:setcode="setCode"></promo>
     <article class="mt-1" v-if="getCards.length != 0">
         <div class="ui large form mt-2" v-if="$store.getters.isLoad == false">
             <div class="field">
@@ -49,11 +50,6 @@
                             <td class="one wide">{{ card.number }}</td>
                             <td>
                                 <input type="text" v-model="card.name" />
-                                <!-- <span
-                                    v-if="card.promotype != ''"
-                                    class="sub header"
-                                    >≪{{ card.promotype }}≫</span
-                                > -->
                             </td>
                             <td>
                                 <select v-model="card.promotype">
@@ -121,6 +117,8 @@ import ListPagination from "../component/ListPagination.vue";
 import ModalButton from "../component/ModalButton.vue";
 import { AxiosTask } from "../../component/AxiosTask";
 import FoilTag from "../component/tag/FoilTag.vue";
+import PromoDropdown from "../component/PromoDropdown.vue";
+import {ref} from 'vue';
 
 import axios from "axios";
 export default {
@@ -131,16 +129,19 @@ export default {
         pagination: ListPagination,
         ModalButton: ModalButton,
         foiltag: FoilTag,
+        promo:PromoDropdown
     },
     data() {
         return {
             filename: "ファイルを選択してください",
-            setCode: this.$route.params.attr,
+            setCode: ref(this.$route.params.attr),
             setName:"",
             isSkip: false,
             isLoading: false,
             isDraftOnly: false,
             color: "",
+            promoItems:[],
+            name:ref("通常版")
         };
     },
     computed: {
@@ -185,9 +186,6 @@ export default {
             };
         },
     },
-    created() {
-        this.isLoading = true;
-    },
     mounted: async function () {
         this.isLoading = true;
         await axios.get('/api/database/exp/' + this.setCode, {})
@@ -199,7 +197,7 @@ export default {
                             })
                             .finally(() => {
                                 this.isLoading = false;
-                            });    
+                            });
     },
     methods: {
         upload: async function (file) {

--- a/resources/js/pages/config/CardInfoCsvPage.vue
+++ b/resources/js/pages/config/CardInfoCsvPage.vue
@@ -1,5 +1,7 @@
 <template>
     <message-area></message-area>
+    <label class="ui header">エキスパンション名:{{setCode}}
+    </label>
     <article class="mt-1 ui grid segment">
         <div
             class="three wide column middle aligned content ui toggle checkbox"
@@ -28,9 +30,6 @@
     </article>
     <article class="mt-1" v-if="getCards.length != 0">
         <div class="ui large form mt-2" v-if="$store.getters.isLoad == false">
-            <div class="inline field">
-                <label>エキスパンション名：</label>{{ setCode }}
-            </div>
             <div class="field">
                 <table class="ui table striped six column">
                     <thead>
@@ -134,7 +133,7 @@ export default {
     data() {
         return {
             filename: "ファイルを選択してください",
-            setCode: "",
+            setCode: this.$route.params.attr,
             isSkip: false,
             isLoading: false,
             isDraftOnly: false,

--- a/resources/js/pages/config/CardInfoCsvPage.vue
+++ b/resources/js/pages/config/CardInfoCsvPage.vue
@@ -1,6 +1,7 @@
 <template>
     <message-area></message-area>
-    <label class="ui header">エキスパンション名:{{setCode}}
+    <div v-if="setName != ''">
+    <label class="ui label">{{setName}}[{{setCode}}]
     </label>
     <article class="mt-1 ui grid segment">
         <div
@@ -104,12 +105,13 @@
                 </div>
             </div>
         </div>
-        <loading
-            :active="isLoading"
-            :can-cancel="false"
-            :is-full-page="true"
-        ></loading>
     </article>
+</div>
+    <loading
+        :active="isLoading"
+        :can-cancel="false"
+        :is-full-page="true"
+    ></loading>
 </template>
 <script>
 import Loading from "vue-loading-overlay";
@@ -125,7 +127,7 @@ export default {
     components: {
         "file-upload": FileUpload,
         "message-area": MessageArea,
-        Loading,
+        "loading":Loading,
         pagination: ListPagination,
         ModalButton: ModalButton,
         foiltag: FoilTag,
@@ -134,6 +136,7 @@ export default {
         return {
             filename: "ファイルを選択してください",
             setCode: this.$route.params.attr,
+            setName:"",
             isSkip: false,
             isLoading: false,
             isDraftOnly: false,
@@ -182,8 +185,21 @@ export default {
             };
         },
     },
-    mounted: function () {
-        // this.$store.dispatch("setLoad", true);
+    created() {
+        this.isLoading = true;
+    },
+    mounted: async function () {
+        this.isLoading = true;
+        await axios.get('/api/database/exp/' + this.setCode, {})
+                            .then((response) => {
+                                this.setName = response.data.name;
+                            })
+                            .catch((e) => {
+                                console.error(e.statusCode);
+                            })
+                            .finally(() => {
+                                this.isLoading = false;
+                            });    
     },
     methods: {
         upload: async function (file) {

--- a/resources/js/pages/config/CardInfoCsvPage.vue
+++ b/resources/js/pages/config/CardInfoCsvPage.vue
@@ -29,7 +29,6 @@
             {{ filename }}
         </div>
     </article>
-    <promo v-model:name="name" v-model:setcode="setCode"></promo>
     <article class="mt-1" v-if="getCards.length != 0">
         <div class="ui large form mt-2" v-if="$store.getters.isLoad == false">
             <div class="field">
@@ -42,7 +41,6 @@
                             <th class="three wide">英名</th>
                             <th>カード仕様</th>
                             <th class="one wide">色</th>
-                            <th class="one wide">言語</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -52,17 +50,7 @@
                                 <input type="text" v-model="card.name" />
                             </td>
                             <td>
-                                <select v-model="card.promotype">
-                                    <option value="">通常版</option>
-                                    <option value="ショーケース">ショーケース</option>
-                                    <option value="ボーダーレス">ボーダーレス</option>
-                                    <option value="ボックストッパー">ボックストッパー</option>
-                                    <option value="ファーストプレイス・Foil">ファーストプレイス・Foil</option>
-                                    <option value="「最大出力」ボーダーレス">「最大出力」ボーダーレス</option>
-                                    <option value="「ワルなライダー」ボーダーレス">「ワルなライダー」ボーダーレス</option>
-                                    <option value="「グラフィティ・ジャイアント」ボーダーレス">「グラフィティ・ジャイアント」ボーダーレス</option>
-                                    <option value="フルアート">フルアート</option>
-                                </select>
+                                <promo v-model:name="card.promotype" v-model:setcode="setCode"></promo>
                             </td>
                             <td>
                                 {{ card.en_name }}
@@ -74,9 +62,6 @@
                                     :class="colorlabel(card.color)"
                                     >{{ colortext(card.color) }}</label
                                 >
-                            </td>
-                            <td>
-                                {{ card.language }}
                             </td>
                         </tr>
                     </tbody>

--- a/resources/js/pages/config/ExpansionPage.vue
+++ b/resources/js/pages/config/ExpansionPage.vue
@@ -47,14 +47,17 @@
                         {{ ex.count }}件
                     </td>
                     <td class="two wide right aligned">
-                        <button class="ui button teal basic" @click="toCsvCardPage(ex.attr)">
-                            <i class="file alternate icon"></i>一括登録</button>
-                        <button
-                            class="ui button teal basic"
-                            @click="toPostCardPage(ex.name, ex.attr)"
-                        >
-                        <i class="plus circle icon"></i>1件登録
-                        </button>
+                        <div class="ui buttons">
+                            <button
+                                class="ui button teal"
+                                @click="toPostCardPage(ex.name, ex.attr)"
+                            >
+                            <i class="plus circle icon"></i>1件登録
+                            </button>
+                            <div class="or"></div>
+                            <button class="ui button teal" @click="toCsvCardPage(ex.attr)">
+                                <i class="file alternate icon"></i>一括登録</button>
+                        </div>
                     </td>
                 </tr>
             </tbody>

--- a/resources/js/pages/config/ExpansionPage.vue
+++ b/resources/js/pages/config/ExpansionPage.vue
@@ -102,13 +102,11 @@ export default {
             );
         },
         search: async function () {
-            console.log(this.keyword);
             this.$store.dispatch("clearCards");
             this.$store.dispatch("setLoad", true);
             const query = { params: { query: this.keyword } };
             const success = function (response, store, query) {
                 store.dispatch("setCard", response.data);
-                // store.dispatch("expansion/result", response.data);
             };
             const fail = function (e, store, query) {
                 const data = e.response.data;

--- a/resources/js/pages/config/ExpansionPage.vue
+++ b/resources/js/pages/config/ExpansionPage.vue
@@ -47,7 +47,8 @@
                         {{ ex.count }}件
                     </td>
                     <td class="two wide right aligned">
-                        <button class="ui button teal basic"><i class="file alternate icon"></i>一括登録</button>
+                        <button class="ui button teal basic" @click="toCsvCardPage(ex.attr)">
+                            <i class="file alternate icon"></i>一括登録</button>
                         <button
                             class="ui button teal basic"
                             @click="toPostCardPage(ex.name, ex.attr)"
@@ -81,12 +82,21 @@ export default {
         show: function () {
             this.$router.push("/config/expansion/post");
         },
+        // カード登録画面に遷移する。
         toPostCardPage: function (setname, attr) {
-            console.log(attr);
             this.$router.push({
                 name: "PostCardInfo",
                 params: { setname: setname, attr: attr },
             });
+        },
+        // カードCSV登録画面に遷移する。
+        toCsvCardPage:function(attr) {
+            this.$router.push(
+                {
+                    name:"CardInfoCsvPage",
+                    params:{attr:attr}
+                }
+            );
         },
         search: async function () {
             console.log(this.keyword);

--- a/resources/js/pages/config/ExpansionPage.vue
+++ b/resources/js/pages/config/ExpansionPage.vue
@@ -28,30 +28,31 @@
         >
             <thead>
                 <tr>
-                    <th class="five wide">名称</th>
-                    <th>略称</th>
+                    <th class="">名称</th>
+                    <th class="">略称</th>
                     <th>リリース日</th>
-                    <th class="center aligned">カード登録件数</th>
-                    <th class="">カード追加</th>
+                    <th class="one wide center aligned">カード件数</th>
+                    <th class="center aligned">カード登録</th>
                 </tr>
             </thead>
             <tbody>
                 <tr v-for="ex in this.$store.getters.card" :key="ex">
                     <td>{{ ex.name }}</td>
-                    <td>{{ ex.attr }}</td>
-                    <td>{{ ex.release_date }}</td>
-                    <td v-if="ex.count != 0" class="positive center aligned">
-                        {{ ex.count }}
+                    <td class="one wide">{{ ex.attr }}</td>
+                    <td class="one wide">{{ ex.release_date }}</td>
+                    <td v-if="ex.count != 0" class="one wide positive center aligned">
+                        {{ ex.count }}件
                     </td>
                     <td v-else class="negative center aligned">
-                        {{ ex.count }}
+                        {{ ex.count }}件
                     </td>
-                    <td>
+                    <td class="two wide right aligned">
+                        <button class="ui button teal basic"><i class="file alternate icon"></i>一括登録</button>
                         <button
                             class="ui button teal basic"
                             @click="toPostCardPage(ex.name, ex.attr)"
                         >
-                            追加する
+                        <i class="plus circle icon"></i>1件登録
                         </button>
                     </td>
                 </tr>

--- a/resources/js/router.js
+++ b/resources/js/router.js
@@ -109,7 +109,7 @@ const routes = [
         prop: true,
     },
     {
-        path: "/config/cardinfo/csv/:attr",
+        path: "/config/cardinfo/csv/:id",
         name:"CardInfoCsvPage",
         component: CardInfoCsvPage,
         meta: {

--- a/resources/js/router.js
+++ b/resources/js/router.js
@@ -109,12 +109,20 @@ const routes = [
         prop: true,
     },
     {
-        path: "/config/cardinfo/csv",
+        path: "/config/cardinfo/csv/:attr",
+        name:"CardInfoCsvPage",
         component: CardInfoCsvPage,
         meta: {
-            title: "カード情報マスタ一括登録",
+            title: "カード情報一括登録",
             description:
-                "MTGJSONからダウンロードしたファイルのカード情報をDBに登録します。",
+                "MTGJSONからDLしたファイルのカード情報をDBに登録します。",
+            urls:[
+                {
+                    url:"/config/expansion",
+                    title:"エキスパンション一覧"
+
+                }
+            ]
         },
     },
     {
@@ -165,14 +173,12 @@ const router = createRouter({
 });
 
 router.beforeEach((to, from, next) => {
-    console.log("start");
     store.dispatch("loading/start");
     next();
 });
 
 router.afterEach(() => {
     store.dispatch("loading/stop");
-    console.log("stop");
 });
 
 // VueRouterインスタンスをエクスポートする

--- a/resources/js/router.js
+++ b/resources/js/router.js
@@ -109,7 +109,7 @@ const routes = [
         prop: true,
     },
     {
-        path: "/config/cardinfo/csv/:id",
+        path: "/config/cardinfo/csv/:attr",
         name:"CardInfoCsvPage",
         component: CardInfoCsvPage,
         meta: {

--- a/routes/api.php
+++ b/routes/api.php
@@ -13,6 +13,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\ArrivalController;
 use App\Http\Controllers\BaseApiController;
+use App\Http\Controllers\PromotypeController;
 use App\Http\Controllers\VendorTypeController;
 
 /*
@@ -44,3 +45,4 @@ Route::apiResource('shipping', ShippingLogController::class);
 Route::get('stockpile', [StockpileController::class, 'index']);
 Route::get('vendor', [VendorTypeController::class, 'index']);
 Route::apiResource('base', BaseApiController::class);
+Route::apiResource('promo', PromotypeController::class);

--- a/tests/Unit/DB/Arrival/ArrivalLogGroupingTest.php
+++ b/tests/Unit/DB/Arrival/ArrivalLogGroupingTest.php
@@ -29,7 +29,6 @@ class ArrivalLogGroupingTest extends TestCase {
         GetApiAssertions::verifyCard as verifyCardFromParent;
     }
 
-
     public function setUp(): void
     {
         parent::setUp();
@@ -66,13 +65,13 @@ class ArrivalLogGroupingTest extends TestCase {
 
     public function arrivalDateProvider() {
         return [
-            // '入荷日_開始日のみ入力' => [[SCon::START_DATE => TestDateUtil::formatYesterday()], $this->equalBefore()],
-            // '入荷日_終了日のみ入力' => [[SCon::END_DATE => TestDateUtil::formatTwoDateBefore()], $this->equalAfter()],
-            // '入荷日_開始日と終了日の両方入力' => [[SCon::START_DATE => TestDateUtil::formatTwoDateBefore(),
-            // SCon::END_DATE => TestDateUtil::formatToday()], $this->between()],
-            // '入荷日_開始日と終了日が同じ日' =>  [[SCon::START_DATE => TestDateUtil::formatToday(),
-            // SCon::END_DATE => TestDateUtil::formatToday()], $this->equals()],
-            // 'カード名のみ入力' => [[SCon::CARD_NAME => 'ジン＝ギタクシアス'], $this->cardname()],
+            '入荷日_開始日のみ入力' => [[SCon::START_DATE => TestDateUtil::formatYesterday()], $this->equalBefore()],
+            '入荷日_終了日のみ入力' => [[SCon::END_DATE => TestDateUtil::formatTwoDateBefore()], $this->equalAfter()],
+            '入荷日_開始日と終了日の両方入力' => [[SCon::START_DATE => TestDateUtil::formatTwoDateBefore(),
+            SCon::END_DATE => TestDateUtil::formatToday()], $this->between()],
+            '入荷日_開始日と終了日が同じ日' =>  [[SCon::START_DATE => TestDateUtil::formatToday(),
+            SCon::END_DATE => TestDateUtil::formatToday()], $this->equals()],
+            'カード名のみ入力' => [[SCon::CARD_NAME => 'ジン＝ギタクシアス'], $this->cardname()],
             '全検索項目入力' => [[SCon::CARD_NAME => '神', SCon::START_DATE => TestDateUtil::formatYesterday(),
             SCon::END_DATE => TestDateUtil::formatYesterday()], $this->condition_all()]
         ];

--- a/tests/Unit/DB/Arrival/ArrivalLogSearchTest.php
+++ b/tests/Unit/DB/Arrival/ArrivalLogSearchTest.php
@@ -66,8 +66,8 @@ class ArrivalLogSearchTest extends TestCase
         return [
             '検索条件が入荷日と取引先カテゴリ' =>
             [[ACon::ARRIVAL_DATE => TestDateUtil::formatToday(), SCon::VENDOR_TYPE_ID => 1]],
-            // '検索条件がカード名と取引先カテゴリ' =>
-            // [[SCon::CARD_NAME => 'ドラゴン', SCon::VENDOR_TYPE_ID => 3]],
+            '検索条件がカード名と取引先カテゴリ' =>
+            [[SCon::CARD_NAME => 'ドラゴン', SCon::VENDOR_TYPE_ID => 3]],
         ];
     }
     

--- a/tests/Unit/DB/Arrival/ArrivalLogSearchTest.php
+++ b/tests/Unit/DB/Arrival/ArrivalLogSearchTest.php
@@ -28,8 +28,8 @@ class ArrivalLogSearchTest extends TestCase
     {
         parent::setUp();
         $this->seed('TruncateAllTables');
-        $this->seed('DatabaseSeeder');
         $this->seed('TestExpansionSeeder');
+        $this->seed('DatabaseSeeder');
         $this->seed('TestCardInfoSeeder');
         $this->seed('TestStockpileSeeder');
         $this->seed('TestArrivalLogSeeder');
@@ -66,8 +66,8 @@ class ArrivalLogSearchTest extends TestCase
         return [
             '検索条件が入荷日と取引先カテゴリ' =>
             [[ACon::ARRIVAL_DATE => TestDateUtil::formatToday(), SCon::VENDOR_TYPE_ID => 1]],
-            '検索条件がカード名と取引先カテゴリ' =>
-            [[SCon::CARD_NAME => 'ドラゴン', SCon::VENDOR_TYPE_ID => 3]],
+            // '検索条件がカード名と取引先カテゴリ' =>
+            // [[SCon::CARD_NAME => 'ドラゴン', SCon::VENDOR_TYPE_ID => 3]],
         ];
     }
     

--- a/tests/Unit/DB/Promo/PromoTypeTest.php
+++ b/tests/Unit/DB/Promo/PromoTypeTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Unit\DB\Promo;
+
+use App\Models\Stockpile;
+use App\Services\Constant\StockpileHeader;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Http\Response;
+use Tests\TestCase;
+use Tests\Trait\GetApiAssertions;
+
+/**
+ * 特別版に関するテストケース
+ */
+class PromoTypeTest extends TestCase
+{
+    use GetApiAssertions;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->seed('TruncateAllTables');
+        $this->seed('TestExpansionSeeder');
+        $this->seed('DatabaseSeeder');
+    }
+
+    /**
+     * A basic feature test example.
+     */
+    public function test_ok(): void
+    {
+        $response = $this->assert_OK([StockpileHeader::SETCODE => 'MH3']);
+    }
+
+    public function test_NoResult() {
+        $this->assert_NG([StockpileHeader::SETCODE => 'XXX'],
+                     Response::HTTP_NOT_FOUND, '検索結果がありません。');
+    }
+
+    /**
+     * エンドポイントを取得する。
+     *
+     * @return string
+     */
+    protected function getEndPoint():string {
+        return  'api/promo';
+    }
+}


### PR DESCRIPTION
## 概要

カード情報一括登録画面のコンポーネントを一部自動化しました。

## 変更点

- エキスパンション一覧画面の検索結果からのみカード情報一括登録画面がアクセスできるようにしました。よって上部メニューのリンクは削除しています。
- promotypeテーブルにexpansionテーブルの外部IDカラムを追加しました。
- 特別版取得APIを実装しました。
- カード情報一括登録画面の特別版ドロップダウンのデータを各エキスパンション別に取得できるようにしました。

## 影響範囲
なし

## ユニットテスト
 PromotypeSearchTest.phpを新たに追加して特別版取得APIのテストを実施しました。

## 関連Issue
なし
