### PR TITLE
Feature/215 Vue側からによる入荷情報削除機能を実装

### DIFF
--- a/resources/js/component/ApiDeleteService.js
+++ b/resources/js/component/ApiDeleteService.js
@@ -1,0 +1,21 @@
+import axios from "axios";
+import {useStore} from 'vuex';
+
+export const apiDeleteService = {
+    // API経由で削除する。
+    delete({url, id, onSuccess, onFinally}) {
+        const store = useStore();
+        axios
+            .get( "/api" + url + id)
+            .then((response) => {
+                onSuccess(response.data);
+            })
+            .catch((e) => {
+                let data = e.response.data;
+                store.dispatch("message/error", data.detail);
+            })
+            .finally(() => {
+                onFinally();
+            });
+    }
+};

--- a/resources/js/component/ApiDeleteService.js
+++ b/resources/js/component/ApiDeleteService.js
@@ -4,11 +4,10 @@ import {useStore} from 'vuex';
 export const apiDeleteService = {
     // API経由で削除する。
     delete({url, id, onSuccess, onFinally}) {
-        const store = useStore();
         axios
-            .get( "/api" + url + id)
-            .then((response) => {
-                onSuccess(response.data);
+        .delete( "/api" + url + id)
+        .then((response) => {
+                onSuccess(response);
             })
             .catch((e) => {
                 let data = e.response.data;

--- a/resources/js/pages/arrival/ArrivalLogDssPage.vue
+++ b/resources/js/pages/arrival/ArrivalLogDssPage.vue
@@ -7,11 +7,13 @@ import ConditionTag from "../component/tag/ConditionTag.vue";
 import {groupConditionStore} from "@/stores/arrival/GroupCondition";
 import { onMounted, reactive } from "vue";
 import {apiService} from "@/component/ApiGetService";
+import { apiDeleteService } from "@/component/ApiDeleteService";
 
 import {ref} from 'vue';
 import Loading from "vue-loading-overlay";
 import pglist from "../component/PgList.vue";
-
+import ModalButton from "../component/ModalButton.vue";
+import { useStore } from 'vuex';
 
 const route = useRoute();
 const router = useRouter();
@@ -59,6 +61,21 @@ const toList = () => {
             name: "ArrivalLogEdit",
             params: { arrival_date:arrival_date, arrival_id: arrival_id},
         });
+    }
+
+    // 入荷情報を1件削除する。
+const deleteLog = async(arrival_id) => {
+    isLoading.value = true;
+    await apiDeleteService.delete({
+        url: "/arrival/", arrival_id,
+        onSuccess: () => {
+            alert("削除しました");
+            toList();
+        },
+        onFinally: () => {
+            isLoading.value = false;
+        }
+    });
     }
 
  const current = (data) => {
@@ -115,8 +132,10 @@ const toList = () => {
                     <td class="center aligned selectable">
                         <a @click="toEditPage(log.id)"><i class="edit icon"></i></a>
                     </td>
-                    <td class="center aligned selectable">
-                        <a class="icon"><i class="trash alternate outline icon"></i></a>
+                    <td class="center aligned">
+                        <ModalButton  :msg="`入荷ID[${log.id}]を削除しますか？`" @action="deleteLog(log.id)">
+                            <i class="trash alternate outline icon"></i>
+                        </ModalButton>
                     </td>
                 </tr>
             </tbody>

--- a/resources/js/pages/arrival/ArrivalLogDssPage.vue
+++ b/resources/js/pages/arrival/ArrivalLogDssPage.vue
@@ -5,6 +5,7 @@ import pagination from "../component/ListPagination.vue";
 import vendortag from "../component/tag/VendorTag.vue"
 import ConditionTag from "../component/tag/ConditionTag.vue";
 import {groupConditionStore} from "@/stores/arrival/GroupCondition";
+import { piniaMsgStore } from "@/stores/global/PiniaMsg";
 import { onMounted, reactive } from "vue";
 import {apiService} from "@/component/ApiGetService";
 import { apiDeleteService } from "@/component/ApiDeleteService";
@@ -13,7 +14,7 @@ import {ref} from 'vue';
 import Loading from "vue-loading-overlay";
 import pglist from "../component/PgList.vue";
 import ModalButton from "../component/ModalButton.vue";
-import { useStore } from 'vuex';
+import PiniaMsgForm from "../component/PiniaMsgForm.vue";
 
 const route = useRoute();
 const router = useRouter();
@@ -21,16 +22,21 @@ const router = useRouter();
 const arrival_date = route.params.arrival_date;
 const vendor_id = route.params.vendor_id;
 const gcStore = groupConditionStore();
+const piniaMsg = piniaMsgStore();
 const currentList = reactive([]);
 const resultCount = ref(0);
 
 const logs = reactive([]);
-
 const isLoading = ref(false);
 
 const result = reactive([]);
 onMounted(async() =>{
     isLoading.value = true;
+    piniaMsg.reset();
+    await fetch();
+    });
+
+const fetch = async() => {
     await apiService.get(
         {
             url:"/arrival/",
@@ -48,7 +54,7 @@ onMounted(async() =>{
                 isLoading.value = false;
             }
         });
-    });
+}
 
 // 入荷情報一覧ページに戻る
 const toList = () => {
@@ -67,9 +73,10 @@ const toList = () => {
 const deleteLog = async(arrival_id) => {
     isLoading.value = true;
     await apiDeleteService.delete({
-        url: "/arrival/", arrival_id,
-        onSuccess: () => {
-            alert("削除しました");
+        url: "/arrival/",
+         id:arrival_id,
+        onSuccess: (response) => {
+            piniaMsg.setSuccess("削除しました。");
             toList();
         },
         onFinally: () => {
@@ -121,7 +128,7 @@ const deleteLog = async(arrival_id) => {
                 </tr>
             </thead>
             <tbody>
-                <tr v-for="(log, index) in currentList.value" :key="index">
+                <tr v-for="(log, index) in currentList.value" :key="index" v-memo="currentList.value">
                     <td class="center aligned">{{log.id}}</td>
                     <td>
                             <cardlayout v-model="log.card"></cardlayout>

--- a/resources/js/pages/arrival/ArrivalLogPage.vue
+++ b/resources/js/pages/arrival/ArrivalLogPage.vue
@@ -9,9 +9,10 @@ import { useStore } from 'vuex';
 import UseDateFormatter from '../../functions/UseDateFormatter.js';
 
 import pglist from "../component/PgList.vue";
-import MessageArea from "../component/MessageArea.vue";
+import PiniaMsgForm from "../component/PiniaMsgForm.vue";
 import foiltag from "../component/tag/FoilTag.vue";
 import {groupConditionStore} from "@/stores/arrival/GroupCondition";
+import { piniaMsgStore } from '@/stores/global/PiniaMsg.js';
 import { storeToRefs } from 'pinia';
 
 const gcStore = groupConditionStore();
@@ -62,6 +63,7 @@ onMounted(async() => {
     if (referrer_path.indexOf('/arrival/') !== 0 ) {
         console.log('pinia reset');
         gcStore.reset();
+        piniaMsgStore().reset();
     }
     await fetch();
 });
@@ -80,7 +82,7 @@ const toDssPage = (arrivalDate, vendor_id) => {
 }
 </script>
 <template>
-    <message-area />
+    <PiniaMsgForm></PiniaMsgForm>
     <article class="mt-1 ui form segment">
         <div class="three fields">
             <div class="four wide field">

--- a/resources/js/pages/component/ModalButton.vue
+++ b/resources/js/pages/component/ModalButton.vue
@@ -10,7 +10,7 @@
         </div>
         <h2 class="ui header">Notice</h2>
         <div class="modal__content">
-            <p>登録してもよろしいですか?</p>
+            <p>{{msg}}</p>
         </div>
         <div class="ui divider"></div>
         <div class="modal__action">
@@ -20,7 +20,7 @@
             <button class="ui teal button" @click="execute">OK</button>
         </div>
     </vue-final-modal>
-    <button class="ui fluid teal button" @click="show">
+    <button class="ui fluid teal icon button" @click="show">
         <slot></slot>
     </button>
 </template>
@@ -31,7 +31,7 @@ export default {
     components: {
         "vue-final-modal": VueFinalModal,
     },
-    props: { },
+    props: { msg: { type: String, default: "登録してもよろしいですか?" } },
     emits: ["action"],
     data() {
         return {

--- a/resources/js/pages/component/PiniaMsgForm.vue
+++ b/resources/js/pages/component/PiniaMsgForm.vue
@@ -1,0 +1,12 @@
+<script setup>
+    import { piniaMsgStore } from "@/stores/global/PiniaMsg";
+    const piniaMsg = piniaMsgStore();
+
+</script>
+<template>
+    <div class="ui positive message"  v-if="piniaMsg.hasSuccess()">
+        <div class="header">
+        {{ piniaMsg.success }}
+        </div>
+    </div>
+</template>

--- a/resources/js/stores/global/piniaMsg.js
+++ b/resources/js/stores/global/piniaMsg.js
@@ -1,0 +1,29 @@
+import { defineStore } from "pinia";
+import { ref } from "vue";
+
+// メッセージを格納するストアを定義する。
+export const piniaMsgStore = defineStore('piniaMsgStore', () =>{
+    const success = ref("");
+    const error = ref([]);
+
+    // 成功メッセージをセットする。
+    function setSuccess(msg) {
+        success.value = msg;
+    }
+
+    // エラーメッセージをセットする。
+    function setError(msg) {
+        error.value = msg;
+    }
+
+    function reset() {
+        success.value = "";
+        error.value = [];
+    }
+
+    function hasSuccess() {
+        return success.value !== "";
+    }
+
+    return {success, error, setSuccess, setError, reset, hasSuccess};
+});

--- a/tests/Unit/DB/Arrival/ArrivalLogDeleteTest.php
+++ b/tests/Unit/DB/Arrival/ArrivalLogDeleteTest.php
@@ -20,6 +20,7 @@ use FiveamCode\LaravelNotionApi\Entities\Page;
 use FiveamCode\LaravelNotionApi\NotionFacade;
 use Tests\Database\Collector\ArrivalLogCollector;
 use FiveamCode\LaravelNotionApi\Entities\Properties\NumberProperty;
+use Illuminate\Testing\TestResponse;
 
 /**
  * 入荷情報削除APIのテストクラス
@@ -177,6 +178,13 @@ class ArrivalLogDeleteTest extends TestCase
         ];
     }
 
+    public function test_削除対象のログが存在しない() {
+        $this->deleteByAPI(999)
+            ->assertStatus(404)->assertJson([
+                'detail' => '指定した情報がありません。',
+            ]);
+    }
+
     private function assertStockpile() {
         return function(?Stockpile $stock, int $expectedQty) {
             $this->assertNotNull($stock, '在庫情報が見つからない');
@@ -196,9 +204,19 @@ class ArrivalLogDeleteTest extends TestCase
             $expectedQty = 0;
         }
 
-        $response = $this->delete('/api/arrival/'.$targetLog->id);
+        $response = $this->deleteByAPI($targetLog->id);
         $response->assertStatus(204);
         return $expectedQty;
+    }
+
+    /**
+     * APIを使用して入荷情報を削除する。
+     *
+     * @param integer $id
+     * @return TestResponse
+     */
+    private function deleteByAPI(int $id): TestResponse{
+        return $this->delete('/api/arrival/'.$id);
     }
 
     /**


### PR DESCRIPTION
## 概要

Vue側からAPIを呼び出して入荷情報を1件削除する機能を実装しました。

## 変更点

- 入荷情報詳細画面の各入荷情報欄に削除ボタンを追加し、API経由で削除できるようにしました。
- Piniaを使ったメッセージ欄(PiniaMsgForm.vue)を作成しました。

## 影響範囲
入荷情報検索画面にPiniaMsgForm.vueを追加しましたが、もしかしたら不適切な場面で「削除しました。」と表示されるかもしれません。
## ユニットテスト
なし。

## 関連Issue
- #214 