### PR TITLE
出荷情報登録:「発送日」をコンポーネントに追加

### DIFF
--- a/.gitmessage.txt
+++ b/.gitmessage.txt
@@ -7,7 +7,7 @@
 :art: デザインUI/UX
 :horse: パフォーマンス
 :wrench: 機能改修
-:rotating_light: テスト
+:test_tube: テスト
 :hankey: 非推奨追加
 :wastebasket: 削除
 :construction: WIP

--- a/app/Http/Requests/Shipt/ShiptPostRequest.php
+++ b/app/Http/Requests/Shipt/ShiptPostRequest.php
@@ -23,14 +23,6 @@ class ShiptPostRequest extends FormRequest
         return true;
     }
 
-    public function prepareForValidation()
-    {
-        $shiptDate = $this->input(ShiptCon::SHIPPING_DATE);
-        $this->merge([
-            ShiptCon::SHIPPING_DATE => CarbonFormatUtil::assignTodayIfMissing($shiptDate),
-        ]);
-    }
-
     /**
      * Get the validation rules that apply to the request.
      *
@@ -41,7 +33,7 @@ class ShiptPostRequest extends FormRequest
         return [
             ShiptCon::ORDER_ID => ['required', new Halfsize()],
             ShiptCon::BUYER => 'required',
-            ShiptCon::SHIPPING_DATE => DateFormatRule::slashRules(),
+            ShiptCon::SHIPPING_DATE => ['required', DateFormatRule::slashRules()],
             ShiptCon::ZIPCODE => ['required', PostalCodeRule::rules()],
             ShiptCon::ADDRESS => 'required|string',
             ShiptCon::ITEMS => ['required','array', 'min:1'],

--- a/app/Http/Resources/Shipt/OrderResource.php
+++ b/app/Http/Resources/Shipt/OrderResource.php
@@ -42,7 +42,6 @@ class OrderResource extends JsonResource
         return [
             SC::ORDER_ID => $this[SC::ORDER_ID],
             SC::BUYER => $row->buyer(),
-            SC::SHIPPING_DATE => $row->shipping_date(),
             SC::ZIPCODE => $row->postal_code(),
             SC::ADDRESS => $row->address(),
             SC::ITEMS => $items,

--- a/app/Http/Validator/ShiptValidator.php
+++ b/app/Http/Validator/ShiptValidator.php
@@ -39,7 +39,6 @@ class ShiptValidator extends AbstractCsvValidator {
    protected function attributes():array {
         return [
             ShiptCon::PRODUCT_PRICE => '商品価格',
-            ShiptCon::DISCOUNT_AMOUNT => '割引額',
             ShiptCon::SINGLE_PRICE => '単価',
             ShiptCon::TOTAL_PRICE => '支払い価格',
             ShiptCon::PRODUCT_ID => '商品コード',

--- a/app/Http/Validator/ShiptValidator.php
+++ b/app/Http/Validator/ShiptValidator.php
@@ -19,7 +19,6 @@ class ShiptValidator extends AbstractCsvValidator {
     return [
         ShiptCon::ORDER_ID => ['required', new Halfsize()],
         ShiptCon::BUYER => 'required',
-        ShiptCon::SHIPPING_DATE => DateFormatRule::slashRules(),
         ShiptCon::POSTAL_CODE => ['required', PostalCodeRule::rules()],
         ShiptCon::STATE => ['required', StateRule::rules()],
         ShiptCon::CITY => 'required|string|regex:/[市区町村郡]/u',
@@ -39,7 +38,6 @@ class ShiptValidator extends AbstractCsvValidator {
      */
    protected function attributes():array {
         return [
-            ShiptCon::SHIPPING_DATE => '発送日',
             ShiptCon::PRODUCT_PRICE => '商品価格',
             ShiptCon::DISCOUNT_AMOUNT => '割引額',
             ShiptCon::SINGLE_PRICE => '単価',

--- a/app/Services/Shipt/ShiptRow.php
+++ b/app/Services/Shipt/ShiptRow.php
@@ -27,11 +27,6 @@ class ShiptRow {
         return $this->number;
     }
 
-    public function shipping_date() {
-        $date = $this->row[SC::SHIPPING_DATE];
-        return CarbonFormatUtil::assignTodayIfMissing($date);
-    }
-
     public function buyer() {
         return $this->row[SC::BUYER];
     }

--- a/app/Services/Shipt/ShiptStoreRow.php
+++ b/app/Services/Shipt/ShiptStoreRow.php
@@ -47,6 +47,15 @@ class ShiptStoreRow extends ShiptRow
     }
 
     /**
+     * 発送日を取得する。
+     *
+     * @return string
+     */
+    public function shipping_date():string {
+        return $this->row[SC::SHIPPING_DATE];
+    }
+
+    /**
      * 商品情報を取得する。
      *
      * @return array

--- a/database/seeders/CsvHeaderSeeder.php
+++ b/database/seeders/CsvHeaderSeeder.php
@@ -7,6 +7,7 @@ use App\Enum\ShopPlatform;
 use App\Models\CsvHeader;
 use Illuminate\Database\Seeder;
 use App\Services\Constant\ShiptConstant as SC;
+use Illuminate\Support\Facades\DB;
 
 class CsvHeaderSeeder extends Seeder
 {
@@ -17,7 +18,8 @@ class CsvHeaderSeeder extends Seeder
      */
     public function run()
     {
-        $mercari_columns = [SC::ORDER_ID, SC::SHIPPING_DATE, SC::PRODUCT_ID, SC::BUYER, SC::PRODUCT_NAME, SC::QUANTITY,
+        CsvHeader::truncate();
+        $mercari_columns = [SC::ORDER_ID, SC::PRODUCT_ID, SC::BUYER, SC::PRODUCT_NAME, SC::QUANTITY,
                      SC::PRODUCT_PRICE, SC::POSTAL_CODE, SC::STATE, SC::CITY, SC::ADDRESS_1, SC::ADDRESS_2, sc::DISCOUNT_AMOUNT];
         for($i = 0; $i < count($mercari_columns); $i++) {
             CsvHeader::create(['shop' => ShopPlatform::MERCARI->value, 'csv_type' => CsvFlowType::SHIPT->value,

--- a/lang/ja/validation.php
+++ b/lang/ja/validation.php
@@ -55,7 +55,7 @@ return [
     'email' => 'The :attribute must be a valid email address.',
     'ends_with' => 'The :attribute must end with one of the following: :values.',
     'enum' => 'The selected :attribute is invalid.',
-    'exists' => ':attributeが存在しません。',
+    'exists' => ':attributeがDBに存在しません。',
     'file' => 'The :attribute must be a file.',
     'filled' => 'The :attribute field must have a value.',
     'gt' => [

--- a/lang/ja/validation.php
+++ b/lang/ja/validation.php
@@ -218,6 +218,7 @@ return [
         SC::STATE => '都道府県名',
         SC::CITY => '市区町村名',
         SC::ADDRESS_1 => 'その他住所1',
+        SC::SHIPPING_DATE => '発送日',
     ],
 
     'values' => [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
-    "version": "5.1.0",
+    "version": "5.2.0",
     "scripts": {
         "dev": "vite --host",
         "build": "vite build",

--- a/resources/js/pages/shipping/ShiptLogImpPage.vue
+++ b/resources/js/pages/shipping/ShiptLogImpPage.vue
@@ -10,6 +10,8 @@
     import ModalButton from '../component/ModalButton.vue';
     import PiniaMsgForm from '../component/PiniaMsgForm.vue';
     import { piniaMsgStore } from '@/stores/global/PiniaMsg.js';
+    import scdatepicker from "../component/SCDatePicker.vue";
+
 
     const result = reactive([]);
     const resultCount = ref(0);
@@ -20,6 +22,7 @@
     const hasError = ref(false);
     const hasResult = ref(false);
     const piniaMsg = piniaMsgStore();
+    const shiptDate = ref(new Date());
 
     onMounted(() => {
         piniaMsg.reset();
@@ -32,10 +35,12 @@
         isLoading.value = true;
         piniaMsg.reset();
         await Promise.all(result.value.map(async (r) => {
+            const formatShiptDate = shiptDate.value.toLocaleDateString("ja-JP", {year: "numeric",month: "2-digit",
+            day: "2-digit"})
             const json =
                 {
                     order_id: r.order_id,
-                    shipping_date: r.shipping_date,
+                    shipping_date: formatShiptDate,
                     buyer_name: r.buyer_name,
                     zip_code: r.zip_code,
                     address: r.address,
@@ -111,19 +116,23 @@
         </div>
     </div>
     <div class="mt-1 ui grid">
-        <div class="row">
-            <div class="three wide left floated column"  v-if="hasResult">
-                <ModalButton  @action="post()">インポート</ModalButton>
-            </div>
-            <div class="seven wide right floated column ui right aligned">
-                <pglist ref="pglistRef" v-model:list="result.value" @loadPage="current"></pglist>
-            </div>
+        <div class="ui form" v-if="hasResult">
+                <div class="two fields">
+                    <div class="nine wide column field">
+                        <label>発送日</label>
+                        <scdatepicker v-model="shiptDate"></scdatepicker>
+                    </div>
+                    <div class="seven wide column field">
+                        <label style="visibility: hidden">インポートボタン</label>
+                            <ModalButton  @action="post()">インポート</ModalButton>
+                        </div>
+                </div>
         </div>
     </div>
-    <div class="mt-1">
+    <div class="mt-2" v-if="hasResult">
         <div class="ui padded segment" v-for="(r, index) in result.value" :key="index">
             <div>
-               {{r.order_id}}<label class="ml-1 ui red  label">{{r.shipping_date}}発送</label>
+                {{r.order_id}}
             </div>
             <address id="buyer" class="ui secondary segment">
                 <p>〒{{ r.zip_code }}</p>
@@ -158,9 +167,12 @@
                 </tbody>
             </table>
         </div>
+        <div class="ui center aligned container">
+            <pglist ref="pglistRef" v-model:list="result.value" @loadPage="current"></pglist>
+        </div>
     </div>
-        <loading
-         :active="isLoading"
+    <loading
+    :active="isLoading"
          :can-cancel="false" :is-full-page="true" />
 
 </template>

--- a/tests/Unit/DB/Shipt/ShiptLogTestHelper.php
+++ b/tests/Unit/DB/Shipt/ShiptLogTestHelper.php
@@ -1,7 +1,10 @@
 <?php
 namespace Tests\Unit\DB\Shipt;
 
+use App\Enum\CsvFlowType;
+use App\Enum\ShopPlatform;
 use App\Exceptions\api\NotFoundException;
+use App\Models\CsvHeader;
 use App\Models\Stockpile;
 use App\Services\Constant\ShiptConstant as SC;
 use App\Services\Constant\CardConstant as CC;
@@ -20,13 +23,13 @@ class ShiptLogTestHelper
      *
      * @return array
      */
-    public static function createBuyerInfo(int $itemCount, string $shiptDate,
+    public static function createBuyerInfo(int $itemCount,
                                                             bool $isFoil = false, bool $isPromo = false, int $quantity = 1):array {
         $items = [];
         for ($i=0; $i < $itemCount; $i++) {
             $items[] = self::createItemInfo($isFoil, $isPromo, $quantity);
         }
-        $buyerInfo = self::createBuyerInfoOnly($shiptDate);
+        $buyerInfo = self::createBuyerInfoOnly();
         $buyerInfo[SC::ITEMS] = $items;
         return $buyerInfo;
     }
@@ -66,10 +69,9 @@ class ShiptLogTestHelper
     /**
      * 購入者情報をランダムで作成する。
      *
-     * @param string $shiptDate
      * @return array
      */
-    public static function createBuyerInfoOnly(string $shiptDate):array {
+    public static function createBuyerInfoOnly():array {
         return [
             SC::ORDER_ID => self::createOrderId(),
             SC::BUYER => fake()->name(),
@@ -78,7 +80,6 @@ class ShiptLogTestHelper
             SC::CITY => fake()->city(),
             SC::ADDRESS_1 => fake()->streetAddress(),
             SC::ADDRESS_2 => fake()->secondaryAddress(),
-            SC::SHIPPING_DATE => $shiptDate,
         ];
     }
 
@@ -88,7 +89,7 @@ class ShiptLogTestHelper
      * @return array
      */
     public static  function createTodayOrderInfos(): array {
-        return ShiptLogTestHelper::createBuyerInfo(1, TestDateUtil::formatToday());
+        return ShiptLogTestHelper::createBuyerInfo(1);
     }
 
 
@@ -166,7 +167,7 @@ class ShiptLogTestHelper
     public static  function getHeader() {
         $header = [
                                 SC::ORDER_ID, SC::BUYER, SC::POSTAL_CODE, SC::STATE,
-                                SC::CITY, SC::ADDRESS_1, SC::ADDRESS_2, SC::SHIPPING_DATE,
+                                SC::CITY, SC::ADDRESS_1, SC::ADDRESS_2,
                                 SC::PRODUCT_ID, SC::PRODUCT_NAME, StockpileHeader::QUANTITY,
                                 SC::PRODUCT_PRICE, SC::DISCOUNT_AMOUNT
                             ];

--- a/tests/Unit/DB/Shipt/ShiptLogTestHelper.php
+++ b/tests/Unit/DB/Shipt/ShiptLogTestHelper.php
@@ -42,10 +42,11 @@ class ShiptLogTestHelper
      * @return array
      */
     public static function createStoreRequest($itemCount = 1):array {
-        $buyerInfo = self::createBuyerInfo($itemCount, TestDateUtil::formatToday());
+        $buyerInfo = self::createBuyerInfo($itemCount);
         $buyerInfo[SC::ADDRESS] = $buyerInfo[SC::STATE].$buyerInfo[SC::CITY].
                                                                 $buyerInfo[SC::ADDRESS_1].' '.$buyerInfo[SC::ADDRESS_2];
         $buyerInfo[SC::ZIPCODE] = $buyerInfo[SC::POSTAL_CODE];
+        $buyerInfo[SC::SHIPPING_DATE] = TestDateUtil::formatToday();
         unset($buyerInfo[SC::STATE]);
         unset($buyerInfo[SC::CITY]);
         unset($buyerInfo[SC::ADDRESS_1]);
@@ -242,6 +243,7 @@ class ShiptLogTestHelper
             SC::TOTAL_PRICE => '支払い金額',
             SC::SINGLE_PRICE => '1枚あたりの単価',
             SC::IS_REGISTERED => '登録済みフラグ',
+            SC::SHIPPING_DATE => '発送日',
             default => $key,
         };
     }

--- a/tests/Unit/DB/Shipt/ShiptParseTest.php
+++ b/tests/Unit/DB/Shipt/ShiptParseTest.php
@@ -76,29 +76,10 @@ class ShiptParseTest extends TestCase
                     "{$i}.". SC::ZIPCODE => $buyer[SC::POSTAL_CODE],
                     "{$i}.". SC::ADDRESS =>
                         $buyer[SC::STATE].$buyer[SC::CITY].$buyer[SC::ADDRESS_1].' '.$buyer[SC::ADDRESS_2],
-                    "{$i}.". SC::SHIPPING_DATE => $buyer[SC::SHIPPING_DATE],
                     "{$i}.". SC::ITEMS => fn($items) => count($items) == count($buyer[SC::ITEMS]),
                 ]);
             });
         }
-    }
-
-    #[TestDox('発送日が正しく設定されているか確認する')]
-    #[TestWith(['td'], '今日')]
-    #[TestWith(['tmr'], '明日')]
-    #[TestWith(['yd'], '昨日')]
-    #[TestWith([''], '未入力')]
-    public function testShippingDate(string $date) {
-        $shiptDate =ShiptLogTestHelper::getShiptDate($date);
-        logger()->info("Testing shipping date: {$shiptDate}");
-        $buyerInfos = [ShiptLogTestHelper::createBuyerInfo(1, $shiptDate)];
-
-        $response = $this->uploadOk($buyerInfos);
-
-        if (empty($shiptDate)) {
-            $shiptDate = TestDateUtil::formatToday();
-        }
-        $response->assertJsonPath('0.'.SC::SHIPPING_DATE, $shiptDate);
     }
 
     #[TestDox('出荷枚数が単品でもセット販売でも正しく設定されているか確認する')]
@@ -215,7 +196,7 @@ class ShiptParseTest extends TestCase
     #[TestWith([false, true], '特別版')]
     #[TestWith([true, true], '特別版のFoilカード')]
     public function testStock(bool $isFoil = false, bool $isPromo = false): void {
-        $buyerInfos = [ShiptLogTestHelper::createBuyerInfo(1, TestDateUtil::formatToday(), $isFoil, $isPromo)];
+        $buyerInfos = [ShiptLogTestHelper::createBuyerInfo(1, $isFoil, $isPromo)];
         $response = $this->uploadOk($buyerInfos);
 
         $items = $buyerInfos[0][SC::ITEMS];
@@ -263,7 +244,7 @@ class ShiptParseTest extends TestCase
                 GC::NAME => $buyerInfos[0][SC::BUYER],
                 SC::ZIPCODE => $buyerInfos[0][SC::POSTAL_CODE],
                 SC::ADDRESS => $buyerInfos[0][SC::STATE].$buyerInfos[0][SC::CITY].$buyerInfos[0][SC::ADDRESS_1].' '.$buyerInfos[0][SC::ADDRESS_2],
-                SC::SHIPPING_DATE => $buyerInfos[0][SC::SHIPPING_DATE],
+                SC::SHIPPING_DATE => TestDateUtil::formatToday(),
                 SC::STOCK_ID => (int)$item[GC::ID],
                 StockpileHeader::QUANTITY => (int)$item[StockpileHeader::QUANTITY],
                 SC::SINGLE_PRICE => fake()->numberBetween(50, 200),
@@ -295,7 +276,6 @@ class ShiptParseTest extends TestCase
             '*' => [
                 SC::ORDER_ID,
                 SC::BUYER,
-                SC::SHIPPING_DATE,
                 SC::ZIPCODE,
                 SC::ADDRESS,
                 SC::ITEMS => [
@@ -335,7 +315,9 @@ class ShiptParseTest extends TestCase
                 ]
             ]);
 
-        return $response;
+            $response->assertJsonMissingPath('*.'.SC::SHIPPING_DATE, '存在しない商品名');
+
+            return $response;
     }
 
     /**
@@ -373,13 +355,13 @@ class ShiptParseTest extends TestCase
         $buyerInfo = ShiptLogTestHelper::createTodayOrderInfos();
         $header  = ShiptLogTestHelper::getHeader();
         // shipping_dateヘッダーを削除
-        $header = str_replace(SC::SHIPPING_DATE, '', $header);
+        $header = str_replace(SC::PRODUCT_ID, '', $header);
         $implode = $this->createCsvLine([$buyerInfo]);
         $content = <<<CSV
         {$header}
         {$implode}
         CSV;
-        $this->verifyFileError($content, 'lack-of-header', SC::SHIPPING_DATE);
+        $this->verifyFileError($content, 'lack-of-header', SC::PRODUCT_ID);
     }
 
     #[TestDox('ファイルエラー: ヘッダーがない')]
@@ -473,7 +455,7 @@ class ShiptParseTest extends TestCase
     public function testNgValidator(): void
     {
         $buyerInfo = ShiptLogTestHelper::createTodayOrderInfos();
-        $buyerInfo[SC::SHIPPING_DATE] = 'aaa';
+        $buyerInfo[SC::POSTAL_CODE] = 'aaa';
 
         $implode = ShiptLogTestHelper::createCsvLine([$buyerInfo]);
         $header = ShiptLogTestHelper::getHeader();
@@ -485,7 +467,7 @@ class ShiptParseTest extends TestCase
         $this->setMockCardBoard([$buyerInfo[SC::ORDER_ID]]);
         $status = CustomResponse::HTTP_CSV_VALIDATION;
         $response = $this->upload($content, $status);
-        $this->assertRowError($response, $status, '発送日はY/m/d形式の日付で入力してください。');
+        $this->assertRowError($response, $status, '郵便番号は「123-4567」の形式で入力してください。');
     }
 
     private function verifyFileError(string $content, string $keyword, string $value = ''): void {

--- a/tests/Unit/DB/Shipt/ShiptParseTest.php
+++ b/tests/Unit/DB/Shipt/ShiptParseTest.php
@@ -405,25 +405,6 @@ class ShiptParseTest extends TestCase
             EC::DETAIL => 'ファイルはCSV形式でアップロードしてください']);
     }
 
-    #[Test]
-    #[TestDox('商品コードが存在しない場合、行数とメッセージが返ってくるか検証する。')]
-    public function ngNoProductId() {
-        $buyerInfo = ShiptLogTestHelper::createTodayOrderInfos();
-        $buyerInfo[SC::ITEMS][0][GC::ID] = '9999';
-        $implode = $this->createCsvLine([$buyerInfo]);
-        $header = ShiptLogTestHelper::getHeader();
-        $content = <<<CSV
-        {$header}
-        {$implode}
-        CSV;
-
-        $this->setMockCardBoard([$buyerInfo[SC::ORDER_ID]]);
-        $status = CustomResponse::HTTP_CSV_VALIDATION;
-
-        $response = $this->upload($content, $status);
-        $this->assertRowError($response, $status, '商品コードが存在しません。');
-    }
-
     #[TestDox('不正な商品情報がある場合、行数とメッセージが返ってくるか検証する。')]
     #[TestWith([SC::ORDER_ID, 'error', 'no-notion'], '注文番号が入力されたNotionカードが存在しない')]
     #[TestWith([SC::QUANTITY, '999', 'excess-shipment'], '出荷枚数が在庫枚数より多い')]

--- a/tests/Unit/DB/Shipt/ShiptPostTest.php
+++ b/tests/Unit/DB/Shipt/ShiptPostTest.php
@@ -18,7 +18,6 @@ use Tests\Database\Seeders\TruncateAllTables;
 use Tests\TestCase;
 use App\Services\Constant\ShiptConstant as SC;
 use App\Services\Constant\StockpileHeader;
-use Carbon\CarbonImmutable;
 use FiveamCode\LaravelNotionApi\Entities\Page;
 use Illuminate\Testing\Fluent\AssertableJson;
 use PHPUnit\Framework\Attributes\TestWith;
@@ -54,7 +53,6 @@ class ShiptPostTest extends TestCase
     #[TestWith(['td'], '今日')]
     #[TestWith(['tmr'], '明日')]
     #[TestWith(['yd'], '昨日')]
-    #[TestWith([''], '未入力')]
     #[TestDox('発送日がどの日付でも登録できることを検証する')]
     public function ok_shippingDate(string $date): void{
         $request = ShiptLogTestHelper::createStoreRequest();

--- a/tests/Unit/Request/Shipt/ShiptPostRequestTest.php
+++ b/tests/Unit/Request/Shipt/ShiptPostRequestTest.php
@@ -10,6 +10,7 @@ use App\Services\Constant\ShiptConstant as SC;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\Attributes\TestWith;
+use Tests\Util\TestDateUtil;
 
 /**
  * ShiptPostRequestクラスをテストするクラス
@@ -18,15 +19,10 @@ use PHPUnit\Framework\Attributes\TestWith;
 class ShiptPostRequestTest extends AbstractValidationTest {
 
     #[Test]
-    #[TestWith(['td'], '発送日が今日')]
-    #[TestWith(['yd'], '発送日が昨日')]
-    #[TestWith(['tmr'], '発送日が明日')]
-    #[TestWith([''], '発送日が未入力')]
-    #[TestDox('発送日に関する正常系テスト')]
-    public function ok_shippingDate(string $dateKey): void {
-        $date = ShiptLogTestHelper::getShiptDate($dateKey);
+    #[TestDox('全項目を入力した正常テスト')]
+    public function ok(): void {
         $request = ShiptLogTestHelper::createStoreRequest();
-        $request[SC::SHIPPING_DATE] = $date;
+        $request[SC::SHIPPING_DATE] = TestDateUtil::formatToday();
         $this->ok_pattern($request);
     }
 
@@ -36,6 +32,7 @@ class ShiptPostRequestTest extends AbstractValidationTest {
     #[TestWith([SC::ZIPCODE], '郵便番号')]
     #[TestWith([SC::ADDRESS], '住所')]
     #[TestWith([SC::ITEMS], '商品情報')]
+    #[TestWith([SC::SHIPPING_DATE], '発送日')]
     #[TestDox('購入者情報の必須項目が未設定の場合のエラーチェック')]
     public function ng_buyer_info_key_lacked(string $key) {
         $request = ShiptLogTestHelper::createStoreRequest();
@@ -55,7 +52,7 @@ class ShiptPostRequestTest extends AbstractValidationTest {
         $request = ShiptLogTestHelper::createStoreRequest();
         unset($request[SC::ITEMS][0][$key]);
         $this->ng_item_info($key, $request, 'は必ず入力してください。');
-        }
+    }
 
     #[Test]
     #[TestWith(['', 'は必ず入力してください。'], '未入力')]
@@ -88,6 +85,13 @@ class ShiptPostRequestTest extends AbstractValidationTest {
     #[TestDox('住所に関するエラーチェック')]
     public function ng_address(string $value, string $msg): void {
         $this->ng_buyer_info(SC::ADDRESS, $value, $msg);
+    }
+
+    #[Test]
+    #[TestWith(['aa', 'はY/m/d形式の日付で入力してください。'], '日付形式ではない')]
+    #[TestDox('発送日に関するエラーチェック')]
+    public function ng_shipping_date(string $value, string $msg): void {
+        $this->ng_buyer_info(SC::SHIPPING_DATE, $value, $msg);
     }
 
     #[Test]

--- a/tests/Unit/Validator/ShiptValidatorTest.php
+++ b/tests/Unit/Validator/ShiptValidatorTest.php
@@ -3,9 +3,9 @@
 namespace Tests\Unit\Validator;
 
 use App\Http\Validator\ShiptValidator;
+use App\Models\Stockpile;
 use App\Services\Constant\GlobalConstant;
 use App\Services\Constant\ErrorConstant as EC;
-use Illuminate\Foundation\Testing\WithFaker;
 use PHPUnit\Framework\Attributes\CoversClass;
 use Tests\TestCase;
 use Tests\Unit\DB\Shipt\ShiptLogTestHelper;
@@ -14,7 +14,6 @@ use App\Services\Constant\StockpileHeader;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\TestDox;
-use PHPUnit\Framework\Attributes\TestWith;
 use Tests\Util\TestDateUtil;
 
 /**
@@ -41,7 +40,6 @@ class ShiptValidatorTest extends TestCase
     {
         return [
             '全て入力済み' => ['', ''],
-            '発送日が未入力' => [SC::SHIPPING_DATE, ''],
             '住所2が未入力' => [SC::ADDRESS_2, ''],
             '市町村名が市名' => [SC::CITY, '○○市'],
             '市町村名が区名' => [SC::CITY, '○○区'],
@@ -72,21 +70,6 @@ class ShiptValidatorTest extends TestCase
     public function ngBuyerName() {
         $this->verifyBuyerError(SC::BUYER, '', '購入者名は必ず入力してください。');
     }
-
-    #[Test]
-    #[TestDox('発送日チェック')]
-    #[DataProvider('shippingDateProvider')]
-    public function ngShippingDate($value, $msg) {
-        $this->verifyBuyerError(SC::SHIPPING_DATE, $value, $msg);
-    }
-
-    public static function shippingDateProvider(): array
-{
-    return [
-        '日付ではない' => ['1111', '発送日はY/m/d形式の日付で入力してください。'],
-        'Y/m/d形式ではない' => ['2025-12-18', '発送日はY/m/d形式の日付で入力してください。'],
-    ];
-}
 
     #[Test]
     #[TestDox('郵便番号チェック')]
@@ -138,7 +121,8 @@ class ShiptValidatorTest extends TestCase
             '未入力' => ['', '商品コードは必ず入力してください。'],
             '文字列' => ['aaa', '商品コードは半角数字を入力してください。'],
             '全角数字' => ['１２３', '商品コードは半角数字を入力してください。'],
-            '0' => ['0', '商品コードは1以上の数字を入力してください。'],
+            '商品コードが0' => ['0', '商品コードは1以上の数字を入力してください。'],
+            '存在しないID' => ['999999', '商品コードがDBに存在しません。'],
         ];
     }
 
@@ -265,10 +249,19 @@ class ShiptValidatorTest extends TestCase
      */
     public function createBuyerInfo() {
         $buyer = ShiptLogTestHelper::createBuyerInfoOnly(TestDateUtil::formatToday());
-        $item =  [GlobalConstant::ID => fake()->randomNumber(), SC::PRODUCT_NAME => fake()->text(50),
+        $item =  [GlobalConstant::ID => $this->randomStockId(), SC::PRODUCT_NAME => fake()->text(50),
                     StockpileHeader::QUANTITY => fake()->numberBetween(1, 10),
                     SC::PRODUCT_PRICE => fake()->numberBetween(300, 10000), SC::DISCOUNT_AMOUNT => 0];
         $buyer[SC::ITEMS] = [$item];
         return $buyer;
+    }
+
+        /**
+         * StockpileテーブルからランダムでIDを取得する。
+         *
+         * @return integer
+         */
+        private function randomStockId():int {
+            return Stockpile::inRandomOrder()->first()->id;
         }
 }


### PR DESCRIPTION
## 概要

「発送日」コンポーネントをWeb画面に追加してAPIで出荷情報を追加できように変更。

## 変更点

このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。

### Vue側
- ShiptLogImpPage.vue:発送日コンポーネントを追加。

### Laravel側
- ShiptValidator.php:バリデーションから発送日を削除。
- OrderResource.php:発送日を削除。
- ShiptRow.php:shipping_date()メソッドを削除。
- ShiptStoreRow.php::shipping_date()メソッドを追加。
- ShiptPostRequest.php:発送日のバリデーションに必須チェックを追加。未入力の場合の処理を削除。
- CsvHeaderSeeder.php:DBデータから発送日を削除。
- package.json:アプリバージョンを「5.2.0」に変更。


## 影響範囲

なし。

## ユニットテスト

このセクションでは、このPRに関連するテストケースやテスト方法を記載してください。

- ShiptParseTest.php:テストケースから発送日を削除。
- ShiptLogTestHelper.php:CSVファイルのデータ作成処理を追加。
- ShiptPostRequestTest.php:発送日の必須チェックに関するテストを追加。
- ShiptPostTest.php:発送日が未入力でもOKになるテストケースを削除。

## 関連Issue

なし。