### PR TITLE
ver.5.2.0

### DIFF
--- a/.gitmessage.txt
+++ b/.gitmessage.txt
@@ -6,7 +6,7 @@
 :books: ドキュメント
 :art: デザインUI/UX
 :horse: パフォーマンス
-:wrench: ツール
+:wrench: 機能改修
 :rotating_light: テスト
 :hankey: 非推奨追加
 :wastebasket: 削除

--- a/.gitmessage.txt
+++ b/.gitmessage.txt
@@ -7,7 +7,7 @@
 :art: デザインUI/UX
 :horse: パフォーマンス
 :wrench: 機能改修
-:rotating_light: テスト
+:test_tube: テスト
 :hankey: 非推奨追加
 :wastebasket: 削除
 :construction: WIP

--- a/app/Http/Requests/Shipt/ShiptPostRequest.php
+++ b/app/Http/Requests/Shipt/ShiptPostRequest.php
@@ -23,14 +23,6 @@ class ShiptPostRequest extends FormRequest
         return true;
     }
 
-    public function prepareForValidation()
-    {
-        $shiptDate = $this->input(ShiptCon::SHIPPING_DATE);
-        $this->merge([
-            ShiptCon::SHIPPING_DATE => CarbonFormatUtil::assignTodayIfMissing($shiptDate),
-        ]);
-    }
-
     /**
      * Get the validation rules that apply to the request.
      *
@@ -41,7 +33,7 @@ class ShiptPostRequest extends FormRequest
         return [
             ShiptCon::ORDER_ID => ['required', new Halfsize()],
             ShiptCon::BUYER => 'required',
-            ShiptCon::SHIPPING_DATE => DateFormatRule::slashRules(),
+            ShiptCon::SHIPPING_DATE => ['required', DateFormatRule::slashRules()],
             ShiptCon::ZIPCODE => ['required', PostalCodeRule::rules()],
             ShiptCon::ADDRESS => 'required|string',
             ShiptCon::ITEMS => ['required','array', 'min:1'],

--- a/app/Http/Resources/Shipt/OrderResource.php
+++ b/app/Http/Resources/Shipt/OrderResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Resources\Shipt;
 
+use App\Enum\ShiptMethod;
 use App\Http\Resources\CardInfoResource;
 use App\Http\Resources\Items\ItemResource;
 use App\Http\Resources\Stockpile\StockpileResource;
@@ -26,16 +27,26 @@ class OrderResource extends JsonResource
     {
         $row = $this[GlobalConstant::DATA];
         $shiptData = $this[SC::ITEMS];
-        $items = [];
+        // 商品価格の合計
+        $productPrice = array_reduce($shiptData, function($carry, $item) {
+            return $carry + $item[SC::PRODUCT_PRICE];
+        }, 0);
+
+        // クーポン割引額の合計
+        $coupon = array_reduce($shiptData, function($carry, $item) {
+            return $carry + $item[SC::DISCOUNT_AMOUNT];
+        }, 0);
+        // 送料
+        $shiptFee = ShiptMethod::findByPrice($productPrice)->price;
         foreach ($shiptData as &$s) {
             $stock = $s[SC::STOCK];
+            $totalPrice = $this->calcTotalPrice($s[SC::PRODUCT_PRICE], $s[SC::DISCOUNT_AMOUNT]);
             $items[] = [
                 SC::STOCK => new ItemResource($stock),
                 SC::SHIPMENT => $s[SC::SHIPMENT],
                 SC::PRODUCT_PRICE => $s[SC::PRODUCT_PRICE],
-                SC::DISCOUNT_AMOUNT => $s[SC::DISCOUNT_AMOUNT],
-                SC::TOTAL_PRICE => $s[SC::TOTAL_PRICE],
-                SC::SINGLE_PRICE => $s[SC::SINGLE_PRICE],
+                SC::TOTAL_PRICE => $totalPrice,
+                SC::SINGLE_PRICE => $this->calcSinglePrice($totalPrice, $shiptFee, $s[SC::SHIPMENT]),
                 SC::IS_REGISTERED => $s[SC::IS_REGISTERED],
             ];
         }
@@ -44,7 +55,35 @@ class OrderResource extends JsonResource
             SC::BUYER => $row->buyer(),
             SC::ZIPCODE => $row->postal_code(),
             SC::ADDRESS => $row->address(),
+            SC::FEE => $shiptFee,
+            SC::PRODUCT_PRICE => $productPrice,
+            SC::TOTAL_PRICE => $totalPrice,
+            SC::DISCOUNT_AMOUNT => $coupon,
             SC::ITEMS => $items,
         ];
+    }
+
+    /**
+     * 支払い金額を算出する。
+     *
+     * @param integer $productPrice 商品価格
+     * @param integer $discount クーポン割引額
+     * @return integer 支払い金額
+     */
+    private function calcTotalPrice(int $productPrice, int $discount):int {
+        return $productPrice - $discount;
+    }
+
+    /**
+     * 単価を算出する。
+     *
+     * @param integer $totalPrice 支払い金額
+     * @param integer $shiptFee 送料
+     * @param integer $shipment 注文枚数
+     * @return integer 単価
+     */
+    private function calcSinglePrice(int $totalPrice,  int $shiptFee, int $shipment):int {
+        $perShipment = round($shiptFee / $shipment);
+        return round(($totalPrice - $perShipment) / $shipment);
     }
 }

--- a/app/Http/Resources/Shipt/OrderResource.php
+++ b/app/Http/Resources/Shipt/OrderResource.php
@@ -50,7 +50,7 @@ class OrderResource extends JsonResource
                 SC::STOCK => new ItemResource($stock),
                 SC::SHIPMENT => $s[SC::SHIPMENT],
                 SC::TOTAL_PRICE => $subTotalPrice,
-                SC::SINGLE_PRICE => $this->calcSinglePrice($subTotalPrice, $shiptFeePerItems, $s[SC::SHIPMENT]),
+                SC::SINGLE_PRICE => $this->calcSinglePrice($subTotalPrice, $s[SC::SHIPMENT]),
                 SC::IS_REGISTERED => $s[SC::IS_REGISTERED],
             ];
         }
@@ -81,12 +81,11 @@ class OrderResource extends JsonResource
      * 単価を算出する。
      *
      * @param integer $totalPrice 支払い金額
-     * @param integer $shiptFeePerItems 1商品あたりの送料
      * @param integer $shipment 注文枚数
      * @return integer 単価
      */
-    private function calcSinglePrice(int $totalPrice,  int $shiptFeePerItems, int $shipment):int {
-        return round(($totalPrice - $shiptFeePerItems) / $shipment);
+    private function calcSinglePrice(int $subtotalPrice, int $shipment):int {
+        return (int)round($subtotalPrice / $shipment);
     }
 
     /**

--- a/app/Http/Resources/Shipt/OrderResource.php
+++ b/app/Http/Resources/Shipt/OrderResource.php
@@ -36,17 +36,21 @@ class OrderResource extends JsonResource
         $coupon = array_reduce($shiptData, function($carry, $item) {
             return $carry + $item[SC::DISCOUNT_AMOUNT];
         }, 0);
+
+        // 商品価格の合計 - クーポン割引額の合計
+        $totalPrice = $this->calcTotalPrice($productPrice, $coupon);
         // 送料
         $shiptFee = ShiptMethod::findByPrice($productPrice)->price;
+
+        $shiptFeePerItems = round($shiptFee / count($shiptData));
         foreach ($shiptData as &$s) {
             $stock = $s[SC::STOCK];
-            $totalPrice = $this->calcTotalPrice($s[SC::PRODUCT_PRICE], $s[SC::DISCOUNT_AMOUNT]);
+            $subTotalPrice = $this->calcSubTotalPrice($s, $shiptFeePerItems);
             $items[] = [
                 SC::STOCK => new ItemResource($stock),
                 SC::SHIPMENT => $s[SC::SHIPMENT],
-                SC::PRODUCT_PRICE => $s[SC::PRODUCT_PRICE],
-                SC::TOTAL_PRICE => $totalPrice,
-                SC::SINGLE_PRICE => $this->calcSinglePrice($totalPrice, $shiptFee, $s[SC::SHIPMENT]),
+                SC::TOTAL_PRICE => $subTotalPrice,
+                SC::SINGLE_PRICE => $this->calcSinglePrice($subTotalPrice, $shiptFeePerItems, $s[SC::SHIPMENT]),
                 SC::IS_REGISTERED => $s[SC::IS_REGISTERED],
             ];
         }
@@ -56,7 +60,6 @@ class OrderResource extends JsonResource
             SC::ZIPCODE => $row->postal_code(),
             SC::ADDRESS => $row->address(),
             SC::FEE => $shiptFee,
-            SC::PRODUCT_PRICE => $productPrice,
             SC::TOTAL_PRICE => $totalPrice,
             SC::DISCOUNT_AMOUNT => $coupon,
             SC::ITEMS => $items,
@@ -78,12 +81,22 @@ class OrderResource extends JsonResource
      * 単価を算出する。
      *
      * @param integer $totalPrice 支払い金額
-     * @param integer $shiptFee 送料
+     * @param integer $shiptFeePerItems 1商品あたりの送料
      * @param integer $shipment 注文枚数
      * @return integer 単価
      */
-    private function calcSinglePrice(int $totalPrice,  int $shiptFee, int $shipment):int {
-        $perShipment = round($shiptFee / $shipment);
-        return round(($totalPrice - $perShipment) / $shipment);
+    private function calcSinglePrice(int $totalPrice,  int $shiptFeePerItems, int $shipment):int {
+        return round(($totalPrice - $shiptFeePerItems) / $shipment);
+    }
+
+    /**
+     * 各商品の小計を算出する。
+     *
+     * @param array $itemData 商品情報
+     * @param integer $shiptFeePerItems 1商品あたりの送料
+     * @return integer 小計
+     */
+    private function calcSubTotalPrice(array $itemData, int $shiptFeePerItems):int {
+        return $itemData[SC::PRODUCT_PRICE] - $itemData[SC::DISCOUNT_AMOUNT] - $shiptFeePerItems;
     }
 }

--- a/app/Http/Resources/Shipt/OrderResource.php
+++ b/app/Http/Resources/Shipt/OrderResource.php
@@ -28,14 +28,14 @@ class OrderResource extends JsonResource
         $row = $this[GlobalConstant::DATA];
         $shiptData = $this[SC::ITEMS];
         // 商品価格の合計
-        $productPrice = array_reduce($shiptData, function($carry, $item) {
-            return $carry + $item[SC::PRODUCT_PRICE];
-        }, 0);
+        $productPrice = $this->collection($shiptData)->sum(function($item) {
+            return $item[SC::PRODUCT_PRICE];
+        });
 
         // クーポン割引額の合計
-        $coupon = array_reduce($shiptData, function($carry, $item) {
-            return $carry + $item[SC::DISCOUNT_AMOUNT];
-        }, 0);
+        $coupon = $this->collection($shiptData)->sum(function($item) {
+            return $item[SC::DISCOUNT_AMOUNT];
+        });
 
         // 商品価格の合計 - クーポン割引額の合計
         $totalPrice = $this->calcTotalPrice($productPrice, $coupon);

--- a/app/Http/Resources/Shipt/OrderResource.php
+++ b/app/Http/Resources/Shipt/OrderResource.php
@@ -42,7 +42,6 @@ class OrderResource extends JsonResource
         return [
             SC::ORDER_ID => $this[SC::ORDER_ID],
             SC::BUYER => $row->buyer(),
-            SC::SHIPPING_DATE => $row->shipping_date(),
             SC::ZIPCODE => $row->postal_code(),
             SC::ADDRESS => $row->address(),
             SC::ITEMS => $items,

--- a/app/Http/Validator/ShiptValidator.php
+++ b/app/Http/Validator/ShiptValidator.php
@@ -39,7 +39,6 @@ class ShiptValidator extends AbstractCsvValidator {
    protected function attributes():array {
         return [
             ShiptCon::PRODUCT_PRICE => '商品価格',
-            ShiptCon::DISCOUNT_AMOUNT => '割引額',
             ShiptCon::SINGLE_PRICE => '単価',
             ShiptCon::TOTAL_PRICE => '支払い価格',
             ShiptCon::PRODUCT_ID => '商品コード',

--- a/app/Http/Validator/ShiptValidator.php
+++ b/app/Http/Validator/ShiptValidator.php
@@ -19,7 +19,6 @@ class ShiptValidator extends AbstractCsvValidator {
     return [
         ShiptCon::ORDER_ID => ['required', new Halfsize()],
         ShiptCon::BUYER => 'required',
-        ShiptCon::SHIPPING_DATE => DateFormatRule::slashRules(),
         ShiptCon::POSTAL_CODE => ['required', PostalCodeRule::rules()],
         ShiptCon::STATE => ['required', StateRule::rules()],
         ShiptCon::CITY => 'required|string|regex:/[市区町村郡]/u',

--- a/app/Http/Validator/ShiptValidator.php
+++ b/app/Http/Validator/ShiptValidator.php
@@ -19,7 +19,6 @@ class ShiptValidator extends AbstractCsvValidator {
     return [
         ShiptCon::ORDER_ID => ['required', new Halfsize()],
         ShiptCon::BUYER => 'required',
-        ShiptCon::SHIPPING_DATE => DateFormatRule::slashRules(),
         ShiptCon::POSTAL_CODE => ['required', PostalCodeRule::rules()],
         ShiptCon::STATE => ['required', StateRule::rules()],
         ShiptCon::CITY => 'required|string|regex:/[市区町村郡]/u',
@@ -39,7 +38,6 @@ class ShiptValidator extends AbstractCsvValidator {
      */
    protected function attributes():array {
         return [
-            ShiptCon::SHIPPING_DATE => '発送日',
             ShiptCon::PRODUCT_PRICE => '商品価格',
             ShiptCon::DISCOUNT_AMOUNT => '割引額',
             ShiptCon::SINGLE_PRICE => '単価',

--- a/app/Http/Validator/ShiptValidator.php
+++ b/app/Http/Validator/ShiptValidator.php
@@ -19,6 +19,7 @@ class ShiptValidator extends AbstractCsvValidator {
     return [
         ShiptCon::ORDER_ID => ['required', new Halfsize()],
         ShiptCon::BUYER => 'required',
+        ShiptCon::SHIPPING_DATE => DateFormatRule::slashRules(),
         ShiptCon::POSTAL_CODE => ['required', PostalCodeRule::rules()],
         ShiptCon::STATE => ['required', StateRule::rules()],
         ShiptCon::CITY => 'required|string|regex:/[市区町村郡]/u',

--- a/app/Models/Shipping.php
+++ b/app/Models/Shipping.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use App\Services\Constant\CardConstant as Con;
+use App\Services\Constant\GlobalConstant as GC;
 /**
  * 発送方法テーブルのModelクラス
  */
@@ -13,7 +14,7 @@ class Shipping extends Model
     use HasFactory;
     protected $table = 'shipping';
 
-    protected $fillable = ['notion_id', Con::NAME, Con::PRICE];
+    protected $fillable = ['notion_id', GC::NAME, Con::PRICE];
 
     public static function findByNotionId(string $notionId) {
         $item = self::where('notion_id', $notionId)->first();
@@ -27,6 +28,6 @@ class Shipping extends Model
      * @return Shipping
      */
     public static function findByMethod(string $method) {
-        return self::where(Con::NAME, $method)->first();
+        return self::where(GC::NAME, $method)->first();
     }
 }

--- a/app/Services/Constant/CardConstant.php
+++ b/app/Services/Constant/CardConstant.php
@@ -6,6 +6,7 @@ class CardConstant {
 
     const SET = 'set';
 
+    /**@deprecated("5.1.0") */
     const NAME = 'name';
 
     const EN_NAME = 'en_name';

--- a/app/Services/Constant/ShiptConstant.php
+++ b/app/Services/Constant/ShiptConstant.php
@@ -23,6 +23,7 @@ class ShiptConstant extends StockpileHeader {
     public const ZIPCODE = "zip_code";
     public const ADDRESS = "address";
     public const DISCOUNT_AMOUNT = "coupon_discount_amount";
+    public const FEE = "shipping_fee";
     public const ITEMS = "items";
     public const SHIPMENT = 'shipment';
     public const SINGLE_PRICE = 'single_price';
@@ -30,10 +31,4 @@ class ShiptConstant extends StockpileHeader {
     public const BUYER_INFO = 'buyer_info';
     public const STOCK_ID = 'stock_id';
     public const IS_REGISTERED = 'isRegistered';
-
-    #[Deprecated(since: "5.1.0", reason: "DBで管理するため不要")]
-    public static function shippinglog_constants() {
-        return [self::ORDER_ID, self::SHIPPING_DATE, self::PRODUCT_ID, self::BUYER, self::PRODUCT_NAME, self::QUANTITY,
-                     self::PRODUCT_PRICE, self::POSTAL_CODE, self::STATE, self::CITY, self::ADDRESS_1,self::ADDRESS_2, self::DISCOUNT_AMOUNT];
-    }
 }

--- a/app/Services/Shipt/ShiptLogService.php
+++ b/app/Services/Shipt/ShiptLogService.php
@@ -3,25 +3,19 @@ namespace App\Services\Shipt;
 
 use App\Exceptions\api\Shipt\ShipmentOrderException;
 use App\Exceptions\api\Shipt\ShiptNotionException;
-use App\Exceptions\NotFoundException;
 use App\Facades\CardBoard;
-use App\Files\CsvReader;
 use App\Files\Reader\ShiptLogCsvReader;
-use App\Models\Shipping;
 use App\Models\ShippingLog;
 use App\Models\Stockpile;
-use App\Repositories\Api\Shipt\ShiptRepository;
 use App\Services\AbstractCsvService;
 use FiveamCode\LaravelNotionApi\Entities\Page;
 use FiveamCode\LaravelNotionApi\Entities\Properties\Date;
 use FiveamCode\LaravelNotionApi\Entities\Properties\Number;
 use FiveamCode\LaravelNotionApi\Entities\Properties\Select;
 use FiveamCode\LaravelNotionApi\Entities\Properties\Text;
-use Illuminate\Http\Client\Response;
 use Illuminate\Http\Response as HttpResponse;
 use App\Services\Constant\CardConstant as Con;
-use App\Services\Constant\GlobalConstant;
-use League\Csv\AbstractCsv;
+use App\Services\Constant\GlobalConstant as GC;
 use App\Services\Constant\ShiptConstant as SC;
 use App\Services\Constant\ErrorConstant as EC;
 use App\Services\Constant\StockpileHeader;
@@ -31,11 +25,6 @@ use DateTime;
  * 出荷ログ機能のサービスクラス
  */
 class ShiptLogService extends AbstractCsvService {
-
-    private $repo;
-    public function __construct() {
-        $this->repo = new ShiptRepository();
-    }
 
     /**
      * 出荷ログ用のCSV読み込みクラスを取得する。
@@ -109,7 +98,7 @@ class ShiptLogService extends AbstractCsvService {
                     // 新規生成
                     $orders[$orderId] = [
                         SC::ORDER_ID => $orderId,
-                        GlobalConstant::DATA => $row,
+                        GC::DATA => $row,
                     ];
                 }
                 // 出荷商品情報チェック
@@ -160,10 +149,10 @@ class ShiptLogService extends AbstractCsvService {
     public function show(string $orderId) {
         $list = ShippingLog::fetchByOrderId($orderId);
         $items = $list->map(function($slog) {
-                return ["id" => $slog["stock_id"],  Con::NAME => $slog["cardname"], Con::EXP => [Con::NAME => $slog[SC::SETNAME], Con::ATTR => $slog['exp_attr']],
+                return ["id" => $slog["stock_id"],  GC::NAME => $slog["cardname"], Con::EXP => [GC::NAME => $slog[SC::SETNAME], Con::ATTR => $slog['exp_attr']],
                              SC::CONDITION => $slog[SC::CONDITION], SC::QUANTITY => $slog->quantity,Con::NUMBER => $slog[Con::NUMBER],
                             SC::LANG => $slog[SC::LANG], Con::IMAGE_URL => $slog[Con::IMAGE_URL],
-                            SC::FOIL => ['is_foil' => $slog['isFoil'], Con::NAME => $slog['foilname']],
+                            SC::FOIL => ['is_foil' => $slog['isFoil'], GC::NAME => $slog['foilname']],
                             'single_price' =>$slog->single_price, 'subtotal_price' => $slog->total_price,
                             Con::PROMOTYPE => [GlobalConstant::ID => $slog->promotype_id, GlobalConstant::NAME => $slog->promo_name
                 ]];

--- a/app/Services/Shipt/ShiptLogService.php
+++ b/app/Services/Shipt/ShiptLogService.php
@@ -48,7 +48,7 @@ class ShiptLogService extends AbstractCsvService {
         $items = $row->items();
         if (!empty($items)) {
             foreach ($items as $item) {
-                $stockId = (int)$item[GlobalConstant::ID];
+                $stockId = (int)$item[GC::ID];
                 // DB登録済みフラグがtrueの場合はスキップ
                 if ($item[SC::IS_REGISTERED]) {
                     logger()->warning("既に登録されています。注文ID:{$row->order_id()}, 氏名:{$row->buyer()}, 在庫ID:{$stockId}");

--- a/app/Services/Shipt/ShiptLogService.php
+++ b/app/Services/Shipt/ShiptLogService.php
@@ -10,6 +10,7 @@ use App\Files\Reader\ShiptLogCsvReader;
 use App\Models\Shipping;
 use App\Models\ShippingLog;
 use App\Models\Stockpile;
+use App\Repositories\Api\Shipt\ShiptRepository;
 use App\Services\AbstractCsvService;
 use FiveamCode\LaravelNotionApi\Entities\Page;
 use FiveamCode\LaravelNotionApi\Entities\Properties\Date;
@@ -30,6 +31,12 @@ use DateTime;
  * 出荷ログ機能のサービスクラス
  */
 class ShiptLogService extends AbstractCsvService {
+
+    private $repo;
+    public function __construct() {
+        $this->repo = new ShiptRepository();
+    }
+
     /**
      * 出荷ログ用のCSV読み込みクラスを取得する。
      * @see CsvReader::csvReader
@@ -115,8 +122,6 @@ class ShiptLogService extends AbstractCsvService {
                     SC::SHIPMENT => $row->shipment(),
                     SC::PRODUCT_PRICE => $row->product_price(),
                     SC::DISCOUNT_AMOUNT => $row->discount(),
-                    SC::SINGLE_PRICE => $row->single_price(),
-                    SC::TOTAL_PRICE => $row->total_price(),
                     SC::IS_REGISTERED => ShippingLog::isExists($orderId, $row->buyer(), $stockId),
                 ];
             } catch (ShipmentOrderException $e) {

--- a/app/Services/Shipt/ShiptRow.php
+++ b/app/Services/Shipt/ShiptRow.php
@@ -87,7 +87,7 @@ class ShiptRow {
 
     /**
      * 1枚あたりの単価を計算する。
-     *
+     *@deprecated 5.2.0
      * @return int
      */
     public function single_price():int {
@@ -97,7 +97,7 @@ class ShiptRow {
 
     /**
      * 支払い価格を計算する。
-     *
+     * @deprecated 5.2.0
      * @return integer
      */
     public function total_price():int {

--- a/app/Services/Shipt/ShiptRow.php
+++ b/app/Services/Shipt/ShiptRow.php
@@ -27,11 +27,6 @@ class ShiptRow {
         return $this->number;
     }
 
-    public function shipping_date() {
-        $date = $this->row[SC::SHIPPING_DATE];
-        return CarbonFormatUtil::assignTodayIfMissing($date);
-    }
-
     public function buyer() {
         return $this->row[SC::BUYER];
     }

--- a/app/Services/Shipt/ShiptStoreRow.php
+++ b/app/Services/Shipt/ShiptStoreRow.php
@@ -47,6 +47,15 @@ class ShiptStoreRow extends ShiptRow
     }
 
     /**
+     * 発送日を取得する。
+     *
+     * @return string
+     */
+    public function shipping_date():string {
+        return $this->row[SC::SHIPPING_DATE];
+    }
+
+    /**
      * 商品情報を取得する。
      *
      * @return array

--- a/database/seeders/CsvHeaderSeeder.php
+++ b/database/seeders/CsvHeaderSeeder.php
@@ -7,6 +7,7 @@ use App\Enum\ShopPlatform;
 use App\Models\CsvHeader;
 use Illuminate\Database\Seeder;
 use App\Services\Constant\ShiptConstant as SC;
+use Illuminate\Support\Facades\DB;
 
 class CsvHeaderSeeder extends Seeder
 {
@@ -17,7 +18,8 @@ class CsvHeaderSeeder extends Seeder
      */
     public function run()
     {
-        $mercari_columns = [SC::ORDER_ID, SC::SHIPPING_DATE, SC::PRODUCT_ID, SC::BUYER, SC::PRODUCT_NAME, SC::QUANTITY,
+        CsvHeader::truncate();
+        $mercari_columns = [SC::ORDER_ID, SC::PRODUCT_ID, SC::BUYER, SC::PRODUCT_NAME, SC::QUANTITY,
                      SC::PRODUCT_PRICE, SC::POSTAL_CODE, SC::STATE, SC::CITY, SC::ADDRESS_1, SC::ADDRESS_2, sc::DISCOUNT_AMOUNT];
         for($i = 0; $i < count($mercari_columns); $i++) {
             CsvHeader::create(['shop' => ShopPlatform::MERCARI->value, 'csv_type' => CsvFlowType::SHIPT->value,

--- a/lang/ja/validation.php
+++ b/lang/ja/validation.php
@@ -55,7 +55,7 @@ return [
     'email' => 'The :attribute must be a valid email address.',
     'ends_with' => 'The :attribute must end with one of the following: :values.',
     'enum' => 'The selected :attribute is invalid.',
-    'exists' => ':attributeが存在しません。',
+    'exists' => ':attributeがDBに存在しません。',
     'file' => 'The :attribute must be a file.',
     'filled' => 'The :attribute field must have a value.',
     'gt' => [

--- a/lang/ja/validation.php
+++ b/lang/ja/validation.php
@@ -218,6 +218,7 @@ return [
         SC::STATE => '都道府県名',
         SC::CITY => '市区町村名',
         SC::ADDRESS_1 => 'その他住所1',
+        SC::SHIPPING_DATE => '発送日',
     ],
 
     'values' => [

--- a/lang/ja/validation.php
+++ b/lang/ja/validation.php
@@ -55,7 +55,7 @@ return [
     'email' => 'The :attribute must be a valid email address.',
     'ends_with' => 'The :attribute must end with one of the following: :values.',
     'enum' => 'The selected :attribute is invalid.',
-    'exists' => ':attributeがDBに存在しません。',
+    'exists' => ':attributeが存在しません。',
     'file' => 'The :attribute must be a file.',
     'filled' => 'The :attribute field must have a value.',
     'gt' => [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
-    "version": "5.1.0",
+    "version": "5.2.0",
     "scripts": {
         "dev": "vite --host",
         "build": "vite build",

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -24,6 +24,7 @@ body {
     font-family: "Exo 2", sans-serif;
     background-image: linear-gradient(to top right, #1e50a2 0%, #d43f8d 100%);
     -webkit-background-clip: text;
+    background-clip: text;
     -webkit-text-fill-color: transparent;
     vertical-align: top;
     font-weight: 400;

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -34,7 +34,7 @@ body {
     padding-block: 0.8rem;
 }
 
-#main>.ui.header {   
+#main>.ui.header {
     color:var(--gray) !important;
 }
 
@@ -81,6 +81,10 @@ body {
 
 .text-center {
     text-align: center;
+}
+
+.pl-0 {
+    padding-left: 0 !important;
 }
 .pl-2 {
     padding-left: 2em !important;

--- a/resources/js/csv/BaseItemContents.js
+++ b/resources/js/csv/BaseItemContents.js
@@ -10,11 +10,14 @@ export default () => {
         header: [
             "商品ID",
             "商品名",
+            "種類ID",
+            "種類名",
             "説明",
             "価格",
             "在庫数",
             "公開状態",
             "表示順",
+            "種類在庫数",
             "画像1",
             "画像2",
             "画像3",
@@ -24,11 +27,14 @@ export default () => {
             let json = [
                 c.baseId,
                 toItemName(c),
+                "",
+                "",
                 this.description(c),
                 this.price(c.price),
                 c.stock,
                 "1",
                 index,
+                "",
                 toSurfaceName(c),
                 toNoLabelName(c)
             ];

--- a/resources/js/pages/shipping/ShiptLogImpPage.vue
+++ b/resources/js/pages/shipping/ShiptLogImpPage.vue
@@ -142,13 +142,16 @@
                 </address>
                 <div class="column">
                     <dl id="price">
-                        <div class="list">
+                        <div class="list" v-if="r.coupon_discount_amount != 0">
                             <dt>クーポン割引</dt>
-                            <dd><i class="bi bi-currency-yen"></i>0</dd>
+                            <dd>
+                                <i class="bi bi-dash"></i>
+                                <i class="bi bi-currency-yen"></i>{{ r.coupon_discount_amount }}
+                            </dd>
                         </div>
                         <div class="list">
                             <dt>送料</dt>
-                            <dd><i class="bi bi-currency-yen"></i>85</dd>
+                            <dd><i class="bi bi-currency-yen"></i>{{ r.shipping_fee }}</dd>
                         </div>
                         <div class="list">
                             <dt>合計金額</dt>
@@ -160,11 +163,10 @@
             <table class="ui striped table">
                 <thead>
                     <tr>
-                        <th class="center aligned">在庫ID</th>
+                        <th class="one wide center aligned">在庫ID</th>
                         <th class="eight wide">カード情報</th>
                         <th class="center aligned">状態</th>
                         <th class="center aligned">枚数</th>
-                        <th class="center aligned">価格</th>
                         <th class="center aligned">単価</th>
                         <th class="center aligned">小計</th>
                     </tr>
@@ -175,7 +177,6 @@
                         <td><cardlayout v-model:card="item.stock.card" v-model:lang="item.stock.lang"/></td>
                         <td class="one wide center aligned"><condition :name="item.stock.condition"/></td>
                         <td class="center aligned">{{ item.shipment }}枚</td>
-                        <td class="center aligned"><i class="bi bi-currency-yen"></i>{{ item.product_price }}</td>
                         <td class="center aligned"><i class="bi bi-currency-yen"></i>{{ item.single_price }}</td>
                         <td class="center aligned"><i class="bi bi-currency-yen"></i>{{ item.total_price }}</td>
                     </tr>
@@ -193,6 +194,11 @@
 </template>
 
 <style scoped>
+
+.ui.grid > table {
+    padding: 0;
+}
+
 #upload_form {
     padding: 1rem;
 }
@@ -220,11 +226,11 @@
 
 #price .list dt::after {
     content: ":";
-    margin-left: 0.25rem;
 }
 
 #price .list dd {
-text-align:  center;
-margin: 0;
+    text-align:  center;
+    margin: 0;
+    margin-left: 0.4rem;
 }
 </style>

--- a/resources/js/pages/shipping/ShiptLogImpPage.vue
+++ b/resources/js/pages/shipping/ShiptLogImpPage.vue
@@ -144,7 +144,7 @@
                     <dl id="price">
                         <div class="list">
                             <dt>クーポン割引</dt>
-                            <dd>ー</dd>
+                            <dd><i class="bi bi-currency-yen"></i>0</dd>
                         </div>
                         <div class="list">
                             <dt>送料</dt>
@@ -214,7 +214,10 @@
 }
 #price .list dt {
     font-weight: 700;
-    }
+    text-align: right;
+    width: 30%;
+}
+
 #price .list dt::after {
     content: ":";
     margin-left: 0.25rem;

--- a/resources/js/pages/shipping/ShiptLogImpPage.vue
+++ b/resources/js/pages/shipping/ShiptLogImpPage.vue
@@ -130,37 +130,52 @@
         </div>
     </div>
     <div class="mt-2" v-if="hasResult">
-        <div class="ui padded segment" v-for="(r, index) in result.value" :key="index">
-            <div>
+        <div class="ui grid segment" v-for="(r, index) in result.value" :key="index" style="padding:1rem">
+            <div class="pl-0">
                 {{r.order_id}}
             </div>
-            <address id="buyer" class="ui secondary segment">
-                <p>〒{{ r.zip_code }}</p>
-                <p>{{ r.address }}</p>
-                <p class="name">{{ r.buyer_name }}様</p>
-            </address>
+            <div class="ui three column row">
+                <address id="buyer" class="column ui secondary segment">
+                    <p>〒{{ r.zip_code }}</p>
+                    <p>{{ r.address }}</p>
+                    <p class="name">{{ r.buyer_name }}様</p>
+                </address>
+                <div class="column">
+                    <dl id="price">
+                        <div class="list">
+                            <dt>クーポン割引</dt>
+                            <dd>ー</dd>
+                        </div>
+                        <div class="list">
+                            <dt>送料</dt>
+                            <dd><i class="bi bi-currency-yen"></i>85</dd>
+                        </div>
+                        <div class="list">
+                            <dt>合計金額</dt>
+                            <dd><i class="bi bi-currency-yen"></i>{{ r.total_price }}</dd>
+                        </div>
+                    </dl>
+                </div>
+            </div>
             <table class="ui striped table">
                 <thead>
                     <tr>
-                        <th class="one wide center aligned">在庫ID</th>
-                        <th class="seven wide">カード情報</th>
+                        <th class="center aligned">在庫ID</th>
+                        <th class="eight wide">カード情報</th>
                         <th class="center aligned">状態</th>
                         <th class="center aligned">枚数</th>
                         <th class="center aligned">価格</th>
-                        <th class="center aligned">クーポン</th>
                         <th class="center aligned">単価</th>
                         <th class="center aligned">小計</th>
                     </tr>
                 </thead>
                 <tbody>
                     <tr v-for="(item, idx) in r.items" :key="idx">
-                        <td class="one wide center aligned">{{ item.stock.id }}</td>
+                        <td class="center aligned">{{ item.stock.id }}</td>
                         <td><cardlayout v-model:card="item.stock.card" v-model:lang="item.stock.lang"/></td>
                         <td class="one wide center aligned"><condition :name="item.stock.condition"/></td>
                         <td class="center aligned">{{ item.shipment }}枚</td>
                         <td class="center aligned"><i class="bi bi-currency-yen"></i>{{ item.product_price }}</td>
-                        <td class="negative center aligned" v-if="item.coupon_discount_amount != 0">&#8722;<i class="bi bi-currency-yen"></i>{{ item.coupon_discount_amount }}</td>
-                        <td class="center aligned" v-if="item.coupon_discount_amount == 0"><i class="bi bi-dash-lg"></i></td>
                         <td class="center aligned"><i class="bi bi-currency-yen"></i>{{ item.single_price }}</td>
                         <td class="center aligned"><i class="bi bi-currency-yen"></i>{{ item.total_price }}</td>
                     </tr>
@@ -193,4 +208,20 @@
     margin-top: 1rem;
 }
 
+#price .list {
+  display: flex;
+  margin-bottom: 0.5rem;
+}
+#price .list dt {
+    font-weight: 700;
+    }
+#price .list dt::after {
+    content: ":";
+    margin-left: 0.25rem;
+}
+
+#price .list dd {
+text-align:  center;
+margin: 0;
+}
 </style>

--- a/resources/js/pages/shipping/ShiptLogImpPage.vue
+++ b/resources/js/pages/shipping/ShiptLogImpPage.vue
@@ -10,6 +10,8 @@
     import ModalButton from '../component/ModalButton.vue';
     import PiniaMsgForm from '../component/PiniaMsgForm.vue';
     import { piniaMsgStore } from '@/stores/global/PiniaMsg.js';
+    import scdatepicker from "../component/SCDatePicker.vue";
+
 
     const result = reactive([]);
     const resultCount = ref(0);
@@ -20,6 +22,7 @@
     const hasError = ref(false);
     const hasResult = ref(false);
     const piniaMsg = piniaMsgStore();
+    const shiptDate = ref(new Date());
 
     onMounted(() => {
         piniaMsg.reset();
@@ -32,10 +35,12 @@
         isLoading.value = true;
         piniaMsg.reset();
         await Promise.all(result.value.map(async (r) => {
+            const formatShiptDate = shiptDate.value.toLocaleDateString("ja-JP", {year: "numeric",month: "2-digit",
+            day: "2-digit"})
             const json =
                 {
                     order_id: r.order_id,
-                    shipping_date: r.shipping_date,
+                    shipping_date: formatShiptDate,
                     buyer_name: r.buyer_name,
                     zip_code: r.zip_code,
                     address: r.address,
@@ -111,19 +116,23 @@
         </div>
     </div>
     <div class="mt-1 ui grid">
-        <div class="row">
-            <div class="three wide left floated column"  v-if="hasResult">
-                <ModalButton  @action="post()">インポート</ModalButton>
-            </div>
-            <div class="seven wide right floated column ui right aligned">
-                <pglist ref="pglistRef" v-model:list="result.value" @loadPage="current"></pglist>
-            </div>
+        <div class="ui form" v-if="hasResult">
+                <div class="two fields">
+                    <div class="nine wide column field">
+                        <label>発送日</label>
+                        <scdatepicker v-model="shiptDate"></scdatepicker>
+                    </div>
+                    <div class="seven wide column field">
+                        <label style="visibility: hidden">インポートボタン</label>
+                            <ModalButton  @action="post()">インポート</ModalButton>
+                        </div>
+                </div>
         </div>
     </div>
-    <div class="mt-1">
+    <div class="mt-2" v-if="hasResult">
         <div class="ui padded segment" v-for="(r, index) in result.value" :key="index">
             <div>
-               {{r.order_id}}<label class="ml-1 ui red  label">{{r.shipping_date}}発送</label>
+                {{r.order_id}}
             </div>
             <address id="buyer" class="ui secondary segment">
                 <p>〒{{ r.zip_code }}</p>
@@ -158,9 +167,12 @@
                 </tbody>
             </table>
         </div>
+        <div class="ui center aligned container">
+            <pglist ref="pglistRef" v-model:list="result.value" @loadPage="current"></pglist>
+        </div>
     </div>
-        <loading
-         :active="isLoading"
+    <loading
+    :active="isLoading"
          :can-cancel="false" :is-full-page="true" />
 
 </template>

--- a/tests/Unit/DB/Shipt/ShiptLogTestHelper.php
+++ b/tests/Unit/DB/Shipt/ShiptLogTestHelper.php
@@ -1,7 +1,10 @@
 <?php
 namespace Tests\Unit\DB\Shipt;
 
+use App\Enum\CsvFlowType;
+use App\Enum\ShopPlatform;
 use App\Exceptions\api\NotFoundException;
+use App\Models\CsvHeader;
 use App\Models\Stockpile;
 use App\Services\Constant\ShiptConstant as SC;
 use App\Services\Constant\CardConstant as CC;
@@ -20,13 +23,13 @@ class ShiptLogTestHelper
      *
      * @return array
      */
-    public static function createBuyerInfo(int $itemCount, string $shiptDate,
+    public static function createBuyerInfo(int $itemCount,
                                                             bool $isFoil = false, bool $isPromo = false, int $quantity = 1):array {
         $items = [];
         for ($i=0; $i < $itemCount; $i++) {
             $items[] = self::createItemInfo($isFoil, $isPromo, $quantity);
         }
-        $buyerInfo = self::createBuyerInfoOnly($shiptDate);
+        $buyerInfo = self::createBuyerInfoOnly();
         $buyerInfo[SC::ITEMS] = $items;
         return $buyerInfo;
     }
@@ -66,10 +69,9 @@ class ShiptLogTestHelper
     /**
      * 購入者情報をランダムで作成する。
      *
-     * @param string $shiptDate
      * @return array
      */
-    public static function createBuyerInfoOnly(string $shiptDate):array {
+    public static function createBuyerInfoOnly():array {
         return [
             SC::ORDER_ID => self::createOrderId(),
             SC::BUYER => fake()->name(),
@@ -78,7 +80,6 @@ class ShiptLogTestHelper
             SC::CITY => fake()->city(),
             SC::ADDRESS_1 => fake()->streetAddress(),
             SC::ADDRESS_2 => fake()->secondaryAddress(),
-            SC::SHIPPING_DATE => $shiptDate,
         ];
     }
 
@@ -88,7 +89,7 @@ class ShiptLogTestHelper
      * @return array
      */
     public static  function createTodayOrderInfos(): array {
-        return ShiptLogTestHelper::createBuyerInfo(1, TestDateUtil::formatToday());
+        return ShiptLogTestHelper::createBuyerInfo(1);
     }
 
 
@@ -166,7 +167,7 @@ class ShiptLogTestHelper
     public static  function getHeader() {
         $header = [
                                 SC::ORDER_ID, SC::BUYER, SC::POSTAL_CODE, SC::STATE,
-                                SC::CITY, SC::ADDRESS_1, SC::ADDRESS_2, SC::SHIPPING_DATE,
+                                SC::CITY, SC::ADDRESS_1, SC::ADDRESS_2,
                                 SC::PRODUCT_ID, SC::PRODUCT_NAME, StockpileHeader::QUANTITY,
                                 SC::PRODUCT_PRICE, SC::DISCOUNT_AMOUNT
                             ];

--- a/tests/Unit/DB/Shipt/ShiptLogTestHelper.php
+++ b/tests/Unit/DB/Shipt/ShiptLogTestHelper.php
@@ -69,7 +69,7 @@ class ShiptLogTestHelper
      * @param string $shiptDate
      * @return array
      */
-    public static function createBuyerInfoOnly():array {
+    public static function createBuyerInfoOnly(string $shiptDate):array {
         return [
             SC::ORDER_ID => self::createOrderId(),
             SC::BUYER => fake()->name(),
@@ -78,6 +78,7 @@ class ShiptLogTestHelper
             SC::CITY => fake()->city(),
             SC::ADDRESS_1 => fake()->streetAddress(),
             SC::ADDRESS_2 => fake()->secondaryAddress(),
+            SC::SHIPPING_DATE => $shiptDate,
         ];
     }
 

--- a/tests/Unit/DB/Shipt/ShiptLogTestHelper.php
+++ b/tests/Unit/DB/Shipt/ShiptLogTestHelper.php
@@ -69,7 +69,7 @@ class ShiptLogTestHelper
      * @param string $shiptDate
      * @return array
      */
-    public static function createBuyerInfoOnly(string $shiptDate):array {
+    public static function createBuyerInfoOnly():array {
         return [
             SC::ORDER_ID => self::createOrderId(),
             SC::BUYER => fake()->name(),
@@ -78,7 +78,6 @@ class ShiptLogTestHelper
             SC::CITY => fake()->city(),
             SC::ADDRESS_1 => fake()->streetAddress(),
             SC::ADDRESS_2 => fake()->secondaryAddress(),
-            SC::SHIPPING_DATE => $shiptDate,
         ];
     }
 

--- a/tests/Unit/DB/Shipt/ShiptLogTestHelper.php
+++ b/tests/Unit/DB/Shipt/ShiptLogTestHelper.php
@@ -42,10 +42,11 @@ class ShiptLogTestHelper
      * @return array
      */
     public static function createStoreRequest($itemCount = 1):array {
-        $buyerInfo = self::createBuyerInfo($itemCount, TestDateUtil::formatToday());
+        $buyerInfo = self::createBuyerInfo($itemCount);
         $buyerInfo[SC::ADDRESS] = $buyerInfo[SC::STATE].$buyerInfo[SC::CITY].
                                                                 $buyerInfo[SC::ADDRESS_1].' '.$buyerInfo[SC::ADDRESS_2];
         $buyerInfo[SC::ZIPCODE] = $buyerInfo[SC::POSTAL_CODE];
+        $buyerInfo[SC::SHIPPING_DATE] = TestDateUtil::formatToday();
         unset($buyerInfo[SC::STATE]);
         unset($buyerInfo[SC::CITY]);
         unset($buyerInfo[SC::ADDRESS_1]);
@@ -242,6 +243,7 @@ class ShiptLogTestHelper
             SC::TOTAL_PRICE => '支払い金額',
             SC::SINGLE_PRICE => '1枚あたりの単価',
             SC::IS_REGISTERED => '登録済みフラグ',
+            SC::SHIPPING_DATE => '発送日',
             default => $key,
         };
     }

--- a/tests/Unit/DB/Shipt/ShiptParseTest.php
+++ b/tests/Unit/DB/Shipt/ShiptParseTest.php
@@ -100,7 +100,7 @@ class ShiptParseTest extends TestCase
     #[TestWith([true, true, true], 'セット販売_特別版[Foil]]')]
     public function testOkSingleAndSetcorrect(bool $isFoil, bool $isPromo, bool $isSet): void {
         $shipment = $isSet ? 2 : 1;
-        $buyerInfos = [ShiptLogTestHelper::createBuyerInfo(1, TestDateUtil::formatToday(), $isFoil, $isPromo, $shipment)];
+        $buyerInfos = [ShiptLogTestHelper::createBuyerInfo(1, $isFoil, $isPromo, $shipment)];
         $buyerInfos[0][SC::ITEMS] = array_map(function($item) use ($isSet, $shipment) {
             $stock = Stockpile::find((int)$item[GC::ID]);
             // セット販売の商品名に変更
@@ -117,7 +117,7 @@ class ShiptParseTest extends TestCase
                     $base = "0.".SC::ITEMS.".{$i}.";
                     $json->whereAll([
                         $base.SC::SHIPMENT => $this->shipment($item),
-                        $base.SC::PRODUCT_PRICE => $item[SC::PRODUCT_PRICE],
+                        $base.SC::STOCK.'.'.GC::ID => $item[GC::ID],
                     ]);
             });
         }

--- a/tests/Unit/DB/Shipt/ShiptParseTest.php
+++ b/tests/Unit/DB/Shipt/ShiptParseTest.php
@@ -164,53 +164,40 @@ class ShiptParseTest extends TestCase
         $response->assertJsonPath('0.'.SC::FEE, $expectedFee);
     }
 
-    #[TestDox('合計金額とクーポン割引合計額が正しく計算されているか確認する')]
-    #[TestWith([0], 'クーポン割引なし')]
-    #[TestWith([100], 'クーポン割引あり')]
-    public function testTotalPriceCalc(int $discount) {
-        $buyerInfos = [ShiptLogTestHelper::createBuyerInfo(2)];
-        // 割引金額を設定
+    #[TestDox('合計金額とクーポン割引合計額、商品別の小計、単価が正しく計算されているか確認する')]
+    #[TestWith([0, 1], '1商品1枚_割引なし')]
+    #[TestWith([0, 1, 2], '1商品2枚_割引なし')]
+    #[TestWith([0, 2, 1], '2商品1枚ずつ_割引なし')]
+    #[TestWith([0, 2, 2], '2商品2枚ずつ_割引なし')]
+    #[TestWith([100, 1, 1], '1商品1枚_割引あり')]
+    #[TestWith([50, 1, 2], '1商品2枚_割引あり')]
+    #[TestWith([80, 1, 2], '2商品1枚_割引あり')]
+    #[TestWith([110, 2, 2], '2商品2枚_割引あり')]
+    public function testTotalPriceCalc(int $discount, int $itemCount, int $quantity = 1): void {
+        $buyerInfos = [ShiptLogTestHelper::createBuyerInfo($itemCount, false, false, $quantity)];
         foreach ($buyerInfos[0][SC::ITEMS] as &$item) {
+            $item[StockpileHeader::QUANTITY] = $quantity;
             $item[SC::DISCOUNT_AMOUNT] = $discount;
         }
-
         $response = $this->uploadOk($buyerInfos);
 
-        $exTotalPrice = array_reduce($buyerInfos[0][SC::ITEMS], function($carry, $item) {
+        $items = current($buyerInfos)[SC::ITEMS];
+        $exTotalPrice = array_reduce($items, function($carry, $item) {
             return $carry + $item[SC::PRODUCT_PRICE];
         }, 0);
-        $exDiscount = $discount * 2;
+        $shiptFee = ShiptMethod::findByPrice($exTotalPrice)->price;
+
+        $exDiscount = $discount * $itemCount;
         $response->assertJsonPath('0.'.SC::TOTAL_PRICE, $exTotalPrice - $exDiscount);
         $response->assertJsonPath('0.'.SC::DISCOUNT_AMOUNT, $exDiscount);
-    }
 
-    #[TestDox('単価が正しく計算されているか確認する')]
-    #[TestWith([false], '出荷枚数1枚_割引なし')]
-    #[TestWith([false, 50], '出荷枚数1枚_割引あり')]
-    #[TestWith([true], '出荷枚数が複数枚_割引なし')]
-    #[TestWith([true, 50], '出荷枚数が複数枚_割引あり')]
-    public function testSinglePriceCalc(bool $isMulti, int $discount = 0): void {
-        $buyerInfos = [ShiptLogTestHelper::createTodayOrderInfos()];
-        // 商品価格と出荷枚数を設定
-        if ($isMulti) {
-            $buyerInfos[0][SC::ITEMS] = [ShiptLogTestHelper::createItemInfo(true, false, 3)];
-        }
-        $item = $buyerInfos[0][SC::ITEMS][0];
-        $item[SC::PRODUCT_PRICE] = 1000;
-        $item[SC::DISCOUNT_AMOUNT] = $discount;
-
-        $response = $this->uploadOk($buyerInfos);
-
-        $items = $buyerInfos[0][SC::ITEMS];
-        for ($i=0; $i < count($items); $i++) {
-            $item = $items[$i];
-            $exTotalPrice = $item[SC::PRODUCT_PRICE] - $item[SC::DISCOUNT_AMOUNT];
-            $exSinglePrice = (int)round($exTotalPrice / $item[StockpileHeader::QUANTITY]);
-            $response->assertJson(function(AssertableJson $json) use($i, $exSinglePrice) {
-            $json->whereAll([
-                "0.".SC::ITEMS.".{$i}.".SC::SINGLE_PRICE => $exSinglePrice,
-                ]);
-            });
+        $shiptFeePerItems = (int)round($shiptFee / $itemCount);
+        // 商品ごとの合計金額と単価が正しいか確認
+        for ($i=0; $i < $itemCount; $i++) {
+            $exSubtotal = $items[$i][SC::PRODUCT_PRICE] - $items[$i][SC::DISCOUNT_AMOUNT] - $shiptFeePerItems;
+            $exSingle = (int)round($exSubtotal / $quantity);
+            $response->assertJsonPath("0.".SC::ITEMS.".{$i}.".SC::TOTAL_PRICE, $exSubtotal);
+            $response->assertJsonPath("0.".SC::ITEMS.".{$i}.".SC::SINGLE_PRICE, $exSingle);
         }
     }
 

--- a/tests/Unit/DB/Shipt/ShiptParseTest.php
+++ b/tests/Unit/DB/Shipt/ShiptParseTest.php
@@ -76,29 +76,10 @@ class ShiptParseTest extends TestCase
                     "{$i}.". SC::ZIPCODE => $buyer[SC::POSTAL_CODE],
                     "{$i}.". SC::ADDRESS =>
                         $buyer[SC::STATE].$buyer[SC::CITY].$buyer[SC::ADDRESS_1].' '.$buyer[SC::ADDRESS_2],
-                    "{$i}.". SC::SHIPPING_DATE => $buyer[SC::SHIPPING_DATE],
                     "{$i}.". SC::ITEMS => fn($items) => count($items) == count($buyer[SC::ITEMS]),
                 ]);
             });
         }
-    }
-
-    #[TestDox('発送日が正しく設定されているか確認する')]
-    #[TestWith(['td'], '今日')]
-    #[TestWith(['tmr'], '明日')]
-    #[TestWith(['yd'], '昨日')]
-    #[TestWith([''], '未入力')]
-    public function testShippingDate(string $date) {
-        $shiptDate =ShiptLogTestHelper::getShiptDate($date);
-        logger()->info("Testing shipping date: {$shiptDate}");
-        $buyerInfos = [ShiptLogTestHelper::createBuyerInfo(1, $shiptDate)];
-
-        $response = $this->uploadOk($buyerInfos);
-
-        if (empty($shiptDate)) {
-            $shiptDate = TestDateUtil::formatToday();
-        }
-        $response->assertJsonPath('0.'.SC::SHIPPING_DATE, $shiptDate);
     }
 
     #[TestDox('出荷枚数が単品でもセット販売でも正しく設定されているか確認する')]
@@ -215,7 +196,7 @@ class ShiptParseTest extends TestCase
     #[TestWith([false, true], '特別版')]
     #[TestWith([true, true], '特別版のFoilカード')]
     public function testStock(bool $isFoil = false, bool $isPromo = false): void {
-        $buyerInfos = [ShiptLogTestHelper::createBuyerInfo(1, TestDateUtil::formatToday(), $isFoil, $isPromo)];
+        $buyerInfos = [ShiptLogTestHelper::createBuyerInfo(1, $isFoil, $isPromo)];
         $response = $this->uploadOk($buyerInfos);
 
         $items = $buyerInfos[0][SC::ITEMS];
@@ -263,7 +244,7 @@ class ShiptParseTest extends TestCase
                 GC::NAME => $buyerInfos[0][SC::BUYER],
                 SC::ZIPCODE => $buyerInfos[0][SC::POSTAL_CODE],
                 SC::ADDRESS => $buyerInfos[0][SC::STATE].$buyerInfos[0][SC::CITY].$buyerInfos[0][SC::ADDRESS_1].' '.$buyerInfos[0][SC::ADDRESS_2],
-                SC::SHIPPING_DATE => $buyerInfos[0][SC::SHIPPING_DATE],
+                SC::SHIPPING_DATE => TestDateUtil::formatToday(),
                 SC::STOCK_ID => (int)$item[GC::ID],
                 StockpileHeader::QUANTITY => (int)$item[StockpileHeader::QUANTITY],
                 SC::SINGLE_PRICE => fake()->numberBetween(50, 200),
@@ -295,7 +276,6 @@ class ShiptParseTest extends TestCase
             '*' => [
                 SC::ORDER_ID,
                 SC::BUYER,
-                SC::SHIPPING_DATE,
                 SC::ZIPCODE,
                 SC::ADDRESS,
                 SC::ITEMS => [
@@ -335,7 +315,9 @@ class ShiptParseTest extends TestCase
                 ]
             ]);
 
-        return $response;
+            $response->assertJsonMissingPath('*.'.SC::SHIPPING_DATE, '存在しない商品名');
+
+            return $response;
     }
 
     /**
@@ -373,13 +355,13 @@ class ShiptParseTest extends TestCase
         $buyerInfo = ShiptLogTestHelper::createTodayOrderInfos();
         $header  = ShiptLogTestHelper::getHeader();
         // shipping_dateヘッダーを削除
-        $header = str_replace(SC::SHIPPING_DATE, '', $header);
+        $header = str_replace(SC::PRODUCT_ID, '', $header);
         $implode = $this->createCsvLine([$buyerInfo]);
         $content = <<<CSV
         {$header}
         {$implode}
         CSV;
-        $this->verifyFileError($content, 'lack-of-header', SC::SHIPPING_DATE);
+        $this->verifyFileError($content, 'lack-of-header', SC::PRODUCT_ID);
     }
 
     #[TestDox('ファイルエラー: ヘッダーがない')]
@@ -473,7 +455,7 @@ class ShiptParseTest extends TestCase
     public function testNgValidator(): void
     {
         $buyerInfo = ShiptLogTestHelper::createTodayOrderInfos();
-        $buyerInfo[SC::SHIPPING_DATE] = 'aaa';
+        $buyerInfo[SC::POSTAL_CODE] = 'aaa';
 
         $implode = ShiptLogTestHelper::createCsvLine([$buyerInfo]);
         $header = ShiptLogTestHelper::getHeader();
@@ -485,7 +467,7 @@ class ShiptParseTest extends TestCase
         $this->setMockCardBoard([$buyerInfo[SC::ORDER_ID]]);
         $status = CustomResponse::HTTP_CSV_VALIDATION;
         $response = $this->upload($content, $status);
-        $this->assertRowError($response, $status, '発送日はY/m/d形式の日付で入力してください。');
+        $this->assertRowError($response, $status, '郵便番号は「123-4567」の形式で入力してください。');
     }
 
     private function verifyFileError(string $content, string $keyword, string $value = ''): void {

--- a/tests/Unit/DB/Shipt/ShiptParseTest.php
+++ b/tests/Unit/DB/Shipt/ShiptParseTest.php
@@ -2,8 +2,10 @@
 
 namespace Tests\Unit\DB\Shipt;
 
+use App\Enum\ShiptMethod;
 use App\Http\Controllers\ShiptLogController;
 use App\Http\Response\CustomResponse;
+use App\Models\Shipping;
 use App\Models\ShippingLog;
 use App\Models\Stockpile;
 use App\Services\CardBoardService;
@@ -68,6 +70,11 @@ class ShiptParseTest extends TestCase
 
         for($i = 0; $i < $buyerCount; $i++) {
             $buyer = $buyerInfos[$i];
+            // 合計額の算出
+            $totalPrice = array_reduce($buyer[SC::ITEMS], function($carry, $item) {
+                return $carry + ($item[SC::PRODUCT_PRICE] - $item[SC::DISCOUNT_AMOUNT]);
+            }, 0);
+
             // 購入者情報の確認
             $response->assertJson(function(AssertableJson $json) use($i, $buyer) {
                 $json->whereAll([
@@ -143,21 +150,38 @@ class ShiptParseTest extends TestCase
         return (int)$item[SC::QUANTITY];
     }
 
-    #[TestDox('支払い金額が正しく計算されているか確認する')]
-    #[TestWith([0], '割引なし')]
-    #[TestWith([100], '割引あり')]
+    #[TestWith([300, 'ミニレター'], '1500円未満はミニレター')]
+    #[TestWith([1500, 'クリックポスト'], '1500円以上10000円未満はクリックポスト')]
+    #[TestWith([10000, '簡易書留'], '10000円以上は簡易書留')]
+    #[TestDox('送料が正しく設定されているか確認する')]
+    public function testShippingFee(int $productPrice, String $method) {
+        $buyerInfo = ShiptLogTestHelper::createTodayOrderInfos();
+        $buyerInfo[SC::ITEMS][0][SC::PRODUCT_PRICE] = $productPrice;
+
+        $response = $this->uploadOk([$buyerInfo]);
+        $expectedFee = Shipping::findByMethod($method)->price;
+
+        $response->assertJsonPath('0.'.SC::FEE, $expectedFee);
+    }
+
+    #[TestDox('合計金額とクーポン割引合計額が正しく計算されているか確認する')]
+    #[TestWith([0], 'クーポン割引なし')]
+    #[TestWith([100], 'クーポン割引あり')]
     public function testTotalPriceCalc(int $discount) {
-        $buyerInfos = [ShiptLogTestHelper::createTodayOrderInfos()];
-        // 商品価格と割引金額を設定
-        $buyerInfos[0][SC::ITEMS][0][SC::DISCOUNT_AMOUNT] = $discount;
+        $buyerInfos = [ShiptLogTestHelper::createBuyerInfo(2)];
+        // 割引金額を設定
+        foreach ($buyerInfos[0][SC::ITEMS] as &$item) {
+            $item[SC::DISCOUNT_AMOUNT] = $discount;
+        }
 
         $response = $this->uploadOk($buyerInfos);
 
-        $exitem = current($buyerInfos[0][SC::ITEMS]);
-        $exProductPrice = $exitem[SC::PRODUCT_PRICE];
-        $exTotalPrice = $exProductPrice - $exitem[SC::DISCOUNT_AMOUNT];
-        $response->assertJsonPath('0.'.SC::ITEMS.'.0.'.SC::PRODUCT_PRICE, $exProductPrice);
-        $response->assertJsonPath('0.'.SC::ITEMS.'.0.'.SC::TOTAL_PRICE, $exTotalPrice);
+        $exTotalPrice = array_reduce($buyerInfos[0][SC::ITEMS], function($carry, $item) {
+            return $carry + $item[SC::PRODUCT_PRICE];
+        }, 0);
+        $exDiscount = $discount * 2;
+        $response->assertJsonPath('0.'.SC::TOTAL_PRICE, $exTotalPrice - $exDiscount);
+        $response->assertJsonPath('0.'.SC::DISCOUNT_AMOUNT, $exDiscount);
     }
 
     #[TestDox('単価が正しく計算されているか確認する')]
@@ -278,6 +302,9 @@ class ShiptParseTest extends TestCase
                 SC::BUYER,
                 SC::ZIPCODE,
                 SC::ADDRESS,
+                SC::TOTAL_PRICE,
+                SC::DISCOUNT_AMOUNT,
+                SC::FEE,
                 SC::ITEMS => [
                     '*' => [
                         SC::STOCK => [
@@ -305,8 +332,6 @@ class ShiptParseTest extends TestCase
                             StockpileHeader::QUANTITY
                         ],
                         SC::SHIPMENT,
-                        SC::PRODUCT_PRICE,
-                        SC::DISCOUNT_AMOUNT,
                         SC::TOTAL_PRICE,
                         SC::SINGLE_PRICE,
                         SC::IS_REGISTERED

--- a/tests/Unit/DB/Shipt/ShiptParseTest.php
+++ b/tests/Unit/DB/Shipt/ShiptParseTest.php
@@ -405,25 +405,6 @@ class ShiptParseTest extends TestCase
             EC::DETAIL => 'ファイルはCSV形式でアップロードしてください']);
     }
 
-    #[Test]
-    #[TestDox('商品コードが存在しない場合、行数とメッセージが返ってくるか検証する。')]
-    public function ngNoProductId() {
-        $buyerInfo = ShiptLogTestHelper::createTodayOrderInfos();
-        $buyerInfo[SC::ITEMS][0][GC::ID] = '9999';
-        $implode = $this->createCsvLine([$buyerInfo]);
-        $header = ShiptLogTestHelper::getHeader();
-        $content = <<<CSV
-        {$header}
-        {$implode}
-        CSV;
-
-        $this->setMockCardBoard([$buyerInfo[SC::ORDER_ID]]);
-        $status = CustomResponse::HTTP_CSV_VALIDATION;
-
-        $response = $this->upload($content, $status);
-        $this->assertRowError($response, $status, '商品コードが存在しません。');
-    }
-
     #[TestDox('不正な商品情報がある場合、行数とメッセージが返ってくるか検証する。')]
     #[TestWith([SC::ORDER_ID, 'error', 'no-notion'], '注文番号が入力されたNotionカードが存在しない')]
     #[TestWith([SC::QUANTITY, '999', 'excess-shipment'], '出荷枚数が在庫枚数より多い')]

--- a/tests/Unit/DB/Shipt/ShiptPostTest.php
+++ b/tests/Unit/DB/Shipt/ShiptPostTest.php
@@ -18,7 +18,6 @@ use Tests\Database\Seeders\TruncateAllTables;
 use Tests\TestCase;
 use App\Services\Constant\ShiptConstant as SC;
 use App\Services\Constant\StockpileHeader;
-use Carbon\CarbonImmutable;
 use FiveamCode\LaravelNotionApi\Entities\Page;
 use Illuminate\Testing\Fluent\AssertableJson;
 use PHPUnit\Framework\Attributes\TestWith;
@@ -54,7 +53,6 @@ class ShiptPostTest extends TestCase
     #[TestWith(['td'], '今日')]
     #[TestWith(['tmr'], '明日')]
     #[TestWith(['yd'], '昨日')]
-    #[TestWith([''], '未入力')]
     #[TestDox('発送日がどの日付でも登録できることを検証する')]
     public function ok_shippingDate(string $date): void{
         $request = ShiptLogTestHelper::createStoreRequest();

--- a/tests/Unit/Request/Shipt/ShiptPostRequestTest.php
+++ b/tests/Unit/Request/Shipt/ShiptPostRequestTest.php
@@ -10,6 +10,7 @@ use App\Services\Constant\ShiptConstant as SC;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\Attributes\TestWith;
+use Tests\Util\TestDateUtil;
 
 /**
  * ShiptPostRequestクラスをテストするクラス
@@ -18,15 +19,10 @@ use PHPUnit\Framework\Attributes\TestWith;
 class ShiptPostRequestTest extends AbstractValidationTest {
 
     #[Test]
-    #[TestWith(['td'], '発送日が今日')]
-    #[TestWith(['yd'], '発送日が昨日')]
-    #[TestWith(['tmr'], '発送日が明日')]
-    #[TestWith([''], '発送日が未入力')]
-    #[TestDox('発送日に関する正常系テスト')]
-    public function ok_shippingDate(string $dateKey): void {
-        $date = ShiptLogTestHelper::getShiptDate($dateKey);
+    #[TestDox('全項目を入力した正常テスト')]
+    public function ok(): void {
         $request = ShiptLogTestHelper::createStoreRequest();
-        $request[SC::SHIPPING_DATE] = $date;
+        $request[SC::SHIPPING_DATE] = TestDateUtil::formatToday();
         $this->ok_pattern($request);
     }
 
@@ -36,6 +32,7 @@ class ShiptPostRequestTest extends AbstractValidationTest {
     #[TestWith([SC::ZIPCODE], '郵便番号')]
     #[TestWith([SC::ADDRESS], '住所')]
     #[TestWith([SC::ITEMS], '商品情報')]
+    #[TestWith([SC::SHIPPING_DATE], '発送日')]
     #[TestDox('購入者情報の必須項目が未設定の場合のエラーチェック')]
     public function ng_buyer_info_key_lacked(string $key) {
         $request = ShiptLogTestHelper::createStoreRequest();
@@ -55,7 +52,7 @@ class ShiptPostRequestTest extends AbstractValidationTest {
         $request = ShiptLogTestHelper::createStoreRequest();
         unset($request[SC::ITEMS][0][$key]);
         $this->ng_item_info($key, $request, 'は必ず入力してください。');
-        }
+    }
 
     #[Test]
     #[TestWith(['', 'は必ず入力してください。'], '未入力')]
@@ -88,6 +85,13 @@ class ShiptPostRequestTest extends AbstractValidationTest {
     #[TestDox('住所に関するエラーチェック')]
     public function ng_address(string $value, string $msg): void {
         $this->ng_buyer_info(SC::ADDRESS, $value, $msg);
+    }
+
+    #[Test]
+    #[TestWith(['aa', 'はY/m/d形式の日付で入力してください。'], '日付形式ではない')]
+    #[TestDox('発送日に関するエラーチェック')]
+    public function ng_shipping_date(string $value, string $msg): void {
+        $this->ng_buyer_info(SC::SHIPPING_DATE, $value, $msg);
     }
 
     #[Test]

--- a/tests/Unit/Validator/ShiptValidatorTest.php
+++ b/tests/Unit/Validator/ShiptValidatorTest.php
@@ -3,9 +3,9 @@
 namespace Tests\Unit\Validator;
 
 use App\Http\Validator\ShiptValidator;
+use App\Models\Stockpile;
 use App\Services\Constant\GlobalConstant;
 use App\Services\Constant\ErrorConstant as EC;
-use Illuminate\Foundation\Testing\WithFaker;
 use PHPUnit\Framework\Attributes\CoversClass;
 use Tests\TestCase;
 use Tests\Unit\DB\Shipt\ShiptLogTestHelper;
@@ -14,7 +14,6 @@ use App\Services\Constant\StockpileHeader;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\TestDox;
-use PHPUnit\Framework\Attributes\TestWith;
 use Tests\Util\TestDateUtil;
 
 /**
@@ -41,7 +40,6 @@ class ShiptValidatorTest extends TestCase
     {
         return [
             '全て入力済み' => ['', ''],
-            '発送日が未入力' => [SC::SHIPPING_DATE, ''],
             '住所2が未入力' => [SC::ADDRESS_2, ''],
             '市町村名が市名' => [SC::CITY, '○○市'],
             '市町村名が区名' => [SC::CITY, '○○区'],
@@ -72,21 +70,6 @@ class ShiptValidatorTest extends TestCase
     public function ngBuyerName() {
         $this->verifyBuyerError(SC::BUYER, '', '購入者名は必ず入力してください。');
     }
-
-    #[Test]
-    #[TestDox('発送日チェック')]
-    #[DataProvider('shippingDateProvider')]
-    public function ngShippingDate($value, $msg) {
-        $this->verifyBuyerError(SC::SHIPPING_DATE, $value, $msg);
-    }
-
-    public static function shippingDateProvider(): array
-{
-    return [
-        '日付ではない' => ['1111', '発送日はY/m/d形式の日付で入力してください。'],
-        'Y/m/d形式ではない' => ['2025-12-18', '発送日はY/m/d形式の日付で入力してください。'],
-    ];
-}
 
     #[Test]
     #[TestDox('郵便番号チェック')]
@@ -138,7 +121,8 @@ class ShiptValidatorTest extends TestCase
             '未入力' => ['', '商品コードは必ず入力してください。'],
             '文字列' => ['aaa', '商品コードは半角数字を入力してください。'],
             '全角数字' => ['１２３', '商品コードは半角数字を入力してください。'],
-            '0' => ['0', '商品コードは1以上の数字を入力してください。'],
+            '商品コードが0' => ['0', '商品コードは1以上の数字を入力してください。'],
+            '存在しないID' => ['999999', '商品コードがDBに存在しません。'],
         ];
     }
 
@@ -265,10 +249,19 @@ class ShiptValidatorTest extends TestCase
      */
     public function createBuyerInfo() {
         $buyer = ShiptLogTestHelper::createBuyerInfoOnly(TestDateUtil::formatToday());
-        $item =  [GlobalConstant::ID => fake()->randomNumber(), SC::PRODUCT_NAME => fake()->text(50),
+        $item =  [GlobalConstant::ID => $this->randomStockId(), SC::PRODUCT_NAME => fake()->text(50),
                     StockpileHeader::QUANTITY => fake()->numberBetween(1, 10),
                     SC::PRODUCT_PRICE => fake()->numberBetween(300, 10000), SC::DISCOUNT_AMOUNT => 0];
         $buyer[SC::ITEMS] = [$item];
         return $buyer;
+    }
+
+        /**
+         * StockpileテーブルからランダムでIDを取得する。
+         *
+         * @return integer
+         */
+        private function randomStockId():int {
+            return Stockpile::inRandomOrder()->first()->id;
         }
 }

--- a/tests/Unit/Validator/ShiptValidatorTest.php
+++ b/tests/Unit/Validator/ShiptValidatorTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\Validator;
 
 use App\Http\Validator\ShiptValidator;
+use App\Models\Stockpile;
 use App\Services\Constant\GlobalConstant;
 use App\Services\Constant\ErrorConstant as EC;
 use Illuminate\Foundation\Testing\WithFaker;
@@ -41,7 +42,6 @@ class ShiptValidatorTest extends TestCase
     {
         return [
             '全て入力済み' => ['', ''],
-            '発送日が未入力' => [SC::SHIPPING_DATE, ''],
             '住所2が未入力' => [SC::ADDRESS_2, ''],
             '市町村名が市名' => [SC::CITY, '○○市'],
             '市町村名が区名' => [SC::CITY, '○○区'],
@@ -72,21 +72,6 @@ class ShiptValidatorTest extends TestCase
     public function ngBuyerName() {
         $this->verifyBuyerError(SC::BUYER, '', '購入者名は必ず入力してください。');
     }
-
-    #[Test]
-    #[TestDox('発送日チェック')]
-    #[DataProvider('shippingDateProvider')]
-    public function ngShippingDate($value, $msg) {
-        $this->verifyBuyerError(SC::SHIPPING_DATE, $value, $msg);
-    }
-
-    public static function shippingDateProvider(): array
-{
-    return [
-        '日付ではない' => ['1111', '発送日はY/m/d形式の日付で入力してください。'],
-        'Y/m/d形式ではない' => ['2025-12-18', '発送日はY/m/d形式の日付で入力してください。'],
-    ];
-}
 
     #[Test]
     #[TestDox('郵便番号チェック')]
@@ -138,7 +123,8 @@ class ShiptValidatorTest extends TestCase
             '未入力' => ['', '商品コードは必ず入力してください。'],
             '文字列' => ['aaa', '商品コードは半角数字を入力してください。'],
             '全角数字' => ['１２３', '商品コードは半角数字を入力してください。'],
-            '0' => ['0', '商品コードは1以上の数字を入力してください。'],
+            '商品コードが0' => ['0', '商品コードは1以上の数字を入力してください。'],
+            '存在しないID' => ['999999', '商品コードがDBに存在しません。'],
         ];
     }
 
@@ -264,11 +250,20 @@ class ShiptValidatorTest extends TestCase
      * @return array
      */
     public function createBuyerInfo() {
-        $buyer = ShiptLogTestHelper::createBuyerInfoOnly(TestDateUtil::formatToday());
-        $item =  [GlobalConstant::ID => fake()->randomNumber(), SC::PRODUCT_NAME => fake()->text(50),
-                    StockpileHeader::QUANTITY => fake()->numberBetween(1, 10),
+        $buyer = ShiptLogTestHelper::createBuyerInfoOnly();
+        $item =  [GlobalConstant::ID => $this->randomStockId(), SC::PRODUCT_NAME => fake()->text(50),
+                            StockpileHeader::QUANTITY => fake()->numberBetween(1, 10),
                     SC::PRODUCT_PRICE => fake()->numberBetween(300, 10000), SC::DISCOUNT_AMOUNT => 0];
         $buyer[SC::ITEMS] = [$item];
         return $buyer;
-        }
+    }
+
+    /**
+     * StockpileテーブルからランダムでIDを取得する。
+     *
+     * @return integer
+     */
+    private function randomStockId():int {
+        return Stockpile::inRandomOrder()->first()->id;
+    }
 }

--- a/tests/Unit/Validator/ShiptValidatorTest.php
+++ b/tests/Unit/Validator/ShiptValidatorTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Unit\Validator;
 
 use App\Http\Validator\ShiptValidator;
-use App\Models\Stockpile;
 use App\Services\Constant\GlobalConstant;
 use App\Services\Constant\ErrorConstant as EC;
 use Illuminate\Foundation\Testing\WithFaker;
@@ -42,6 +41,7 @@ class ShiptValidatorTest extends TestCase
     {
         return [
             '全て入力済み' => ['', ''],
+            '発送日が未入力' => [SC::SHIPPING_DATE, ''],
             '住所2が未入力' => [SC::ADDRESS_2, ''],
             '市町村名が市名' => [SC::CITY, '○○市'],
             '市町村名が区名' => [SC::CITY, '○○区'],
@@ -72,6 +72,21 @@ class ShiptValidatorTest extends TestCase
     public function ngBuyerName() {
         $this->verifyBuyerError(SC::BUYER, '', '購入者名は必ず入力してください。');
     }
+
+    #[Test]
+    #[TestDox('発送日チェック')]
+    #[DataProvider('shippingDateProvider')]
+    public function ngShippingDate($value, $msg) {
+        $this->verifyBuyerError(SC::SHIPPING_DATE, $value, $msg);
+    }
+
+    public static function shippingDateProvider(): array
+{
+    return [
+        '日付ではない' => ['1111', '発送日はY/m/d形式の日付で入力してください。'],
+        'Y/m/d形式ではない' => ['2025-12-18', '発送日はY/m/d形式の日付で入力してください。'],
+    ];
+}
 
     #[Test]
     #[TestDox('郵便番号チェック')]
@@ -123,8 +138,7 @@ class ShiptValidatorTest extends TestCase
             '未入力' => ['', '商品コードは必ず入力してください。'],
             '文字列' => ['aaa', '商品コードは半角数字を入力してください。'],
             '全角数字' => ['１２３', '商品コードは半角数字を入力してください。'],
-            '商品コードが0' => ['0', '商品コードは1以上の数字を入力してください。'],
-            '存在しないID' => ['999999', '商品コードがDBに存在しません。'],
+            '0' => ['0', '商品コードは1以上の数字を入力してください。'],
         ];
     }
 
@@ -250,20 +264,11 @@ class ShiptValidatorTest extends TestCase
      * @return array
      */
     public function createBuyerInfo() {
-        $buyer = ShiptLogTestHelper::createBuyerInfoOnly();
-        $item =  [GlobalConstant::ID => $this->randomStockId(), SC::PRODUCT_NAME => fake()->text(50),
-                            StockpileHeader::QUANTITY => fake()->numberBetween(1, 10),
+        $buyer = ShiptLogTestHelper::createBuyerInfoOnly(TestDateUtil::formatToday());
+        $item =  [GlobalConstant::ID => fake()->randomNumber(), SC::PRODUCT_NAME => fake()->text(50),
+                    StockpileHeader::QUANTITY => fake()->numberBetween(1, 10),
                     SC::PRODUCT_PRICE => fake()->numberBetween(300, 10000), SC::DISCOUNT_AMOUNT => 0];
         $buyer[SC::ITEMS] = [$item];
         return $buyer;
-    }
-
-    /**
-     * StockpileテーブルからランダムでIDを取得する。
-     *
-     * @return integer
-     */
-    private function randomStockId():int {
-        return Stockpile::inRandomOrder()->first()->id;
-    }
+        }
 }


### PR DESCRIPTION
## 概要
### BASE用商品登録CSVダウンロード機能
BASEショップのアップデートに対応。

### 出荷情報解析機能
- 発送日をWeb画面から設定できるように改修。
- 送料とクーポン割引合計額、合計金額をレスポンスに追加。

### 出荷情報登録機能
リクエストの発送日を必須項目に変更。

## 変更点

### BASE用商品登録CSVダウンロード機能
BaseItemContents.jsのCSVヘッダーに「種類ID」「種類名」「種類在庫数」を追加。各項目のデータは全て空文字を設定。

### 出荷情報解析機能
#### Vue側
- 購入者情報に表示していた発送日を削除。代わりに「インポートボタン」の左側に発送日コンポーネントを追加。
- 各購入者情報に「クーポン割引合計額」「送料」「合計金額」を追加。

#### Laravel側
- レスポンスから発送日を削除。
- レスポンスに送料とクーポン割引合計額、合計金額を追加。

### 出荷情報登録機能
ShiptPostRequestクラスの発送日を必須項目に変更。それに伴い未入力対応処理を削除。

## 影響範囲
なし

## ユニットテスト
- ShiptParseTest.php
- ShiptLogTestHelper.php
- ShiptValidatorTest.php
- ShiptPostRequestTest.php

close #268, #270, #273