### PR TITLE
Scryfall API連携の不具合修正

### DIFF
--- a/app/Api/Client/AbstractApiClient.php
+++ b/app/Api/Client/AbstractApiClient.php
@@ -1,0 +1,19 @@
+<?php
+namespace App\Api\Client;
+/**
+ * 外部APIへの接続設定クラス
+ */
+abstract class AbstractApiClient
+{
+    /**
+     * APIのベースURLを取得する。
+     *
+     * @return string APIのベースURL
+     */
+    abstract public function baseUrl():string;
+
+    public function headers():array
+    {
+        return [];
+    }
+}

--- a/app/Api/Client/ScryfallClient.php
+++ b/app/Api/Client/ScryfallClient.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Api\Client;
+/**
+ * Scryfall APIの接続設定クラス
+ */
+class ScryfallClient extends AbstractApiClient
+{
+    public function baseUrl():string
+    {
+        return "https://api.scryfall.com/";
+    }
+
+    public function headers():array
+    {
+        return [
+             'User-Agent' => 'MyMTGApp/1.0 (beninekoyamtg@gmail.com)',
+            'Accept' => 'application/json;q=0.9,*/*;q=0.8'
+        ];
+    }
+}

--- a/app/Enum/CardColor.php
+++ b/app/Enum/CardColor.php
@@ -71,7 +71,7 @@ enum CardColor:string {
         return $color;
     }
 
-    
+
     public function colorMulti() {
         $ope = "not";
         switch($this) {
@@ -141,7 +141,7 @@ enum CardColor:string {
 
     /**
      * カード情報からCardColorを取得する。
-     * 
+     *
      */
     public static function match(array $card) {
         $colorKey = "colors";
@@ -150,25 +150,25 @@ enum CardColor:string {
         // 無色
         if (!array_key_exists($colorKey, $card)) {
             return CardColor::LESS;
-        } 
+        }
         $colorArray = $card[$colorKey];
         return self::findColor($colorArray, $types);
     }
 
     public static function findColor(array $color, array $cardtype) {
         // アーティファクト
-        if ($cardtype === ['Artifact'] && empty($color)) {
+        if (self::isArtifact($color, $cardtype)) {
             return CardColor::ARTIFACT;
         }
         // 土地
-        if (in_array('Land', $cardtype)) {
+        if (self::isLand($cardtype)) {
             return CardColor::LAND;
         }
 
         // 無色
         if (empty($color)) {
             return CardColor::LESS;
-        } 
+        }
 
         // 多色
         if (count($color) > 1) {
@@ -176,5 +176,33 @@ enum CardColor:string {
         }
         // 単色
         return CardColor::tryFrom(current($color));
+    }
+
+    /**
+     * カードの色がアーティファクトか判断する。
+     *
+     * @param array $color カードの色
+     * @param array $cardtype カードタイプ
+     * @return boolean
+     */
+    private static function isArtifact(array $color, array $cardtype):bool {
+        // 含む要素があるか判定
+        return self::isContains($cardtype, 'Artifact') && empty($color);
+    }
+
+    /**
+     * カードの色が土地か判断する。
+     *
+     * @param array $cardtype カードタイプ
+     * @return boolean
+     */
+    private static function isLand(array $cardtype):bool {
+        return self::isContains($cardtype, 'Land');
+    }
+
+    private static function isContains(array $cardtype, string $target):bool {
+        // 含む要素があるか判定
+        $results = array_filter($cardtype, fn($item) => str_contains($item, $target));
+        return count($results) > 0;
     }
 }

--- a/app/Enum/ExternalApi.php
+++ b/app/Enum/ExternalApi.php
@@ -1,0 +1,30 @@
+<?php
+namespace App\Enum;
+use App\Api\Client\AbstractApiClient;
+use App\Api\Client\ScryfallClient;
+
+/**
+ * 外部APIの種類Enum
+ */
+enum ExternalApi: string
+{
+    // case BASE = 'base';
+    // case WISDOM_GUILD = 'wisdom';
+    case SCRYFALL = 'scryfall';
+    // case MTGDEV = 'mtgdev';
+
+    /**
+     * 外部API別の接続クラスを取得する。
+     *
+     * @return AbstractApiClient
+     */
+    public function client(): AbstractApiClient
+    {
+        return match($this) {
+            // self::BASE => new \App\Api\Client\BaseClient(),
+            // self::WISDOM_GUILD => new \App\Api\Client\WisdomGuildClient(),
+            self::SCRYFALL => new ScryfallClient(),
+            // self::MTGDEV => new \App\Api\Client\MtgDevClient(),
+        };
+    }
+}

--- a/app/Exceptions/api/Connect/ApiConnectException.php
+++ b/app/Exceptions/api/Connect/ApiConnectException.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Http\Response;
+
+/**
+ * 外部APIとの連携に失敗した場合の例外クラス
+ */
+class ApiConnectException extends ApiException {
+
+    public function getTitle(): string
+    {
+        return 'API接続エラー';
+    }
+
+    public function getStatusCode(): int
+    {
+        return Response::HTTP_BAD_GATEWAY;
+    }
+
+    public function getDetail(): string
+    {
+        return '外部APIへの接続に失敗しました。';
+    }
+}

--- a/app/Factory/GuzzleClientFactory.php
+++ b/app/Factory/GuzzleClientFactory.php
@@ -1,6 +1,8 @@
 <?php
 
 namespace App\Factory;
+
+use App\Enum\ExternalApi;
 use GuzzleHttp\Client;
 
 use Illuminate\Support\Arr;
@@ -23,5 +25,11 @@ class GuzzleClientFactory {
     public static function createByUrl($url) {
         $client = new Client(['base_uri' => $url, 'allow_redirects' => ['track_redirects' => true]]);
         return $client;
+    }
+
+    public static function createClient(ExternalApi $api) {
+        $client = $api->client();
+        $guzzleClient = new Client(['base_uri' => $client->baseUrl(), 'headers' => $client->headers(), 'allow_redirects' => ['track_redirects' => true]]);
+        return $guzzleClient;
     }
 }

--- a/app/Http/Controllers/Api/ScryfallController.php
+++ b/app/Http/Controllers/Api/ScryfallController.php
@@ -1,15 +1,13 @@
 <?php
 
-namespace App\Http\Controllers;
+namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\ScryfallRequest;
-use App\Services\ScryfallService;
-use Illuminate\Http\Request;
+use App\Http\Resources\Api\ScryfallResource;
+use App\Services\Api\ScryfallService;
 use Illuminate\Http\Response;
-use App\Services\Constant\CardConstant as Con;
 use App\Services\Constant\GlobalConstant;
-use App\Services\Constant\StockpileHeader as Header;
 
 /**
  * Scryfall APIに接続するコントローラークラス
@@ -25,6 +23,6 @@ class ScryfallController extends Controller
     public function index(ScryfallRequest $request) {
         $details = $request->only(GlobalConstant::DATA);
         $card = $this->service->getCardInfoByNumber($details[GlobalConstant::DATA]);
-        return response()->json($card, Response::HTTP_OK);
+        return response()->json(new ScryfallResource($card), Response::HTTP_OK);
     }
 }

--- a/app/Http/Controllers/ScryfallController.php
+++ b/app/Http/Controllers/ScryfallController.php
@@ -8,6 +8,7 @@ use App\Services\ScryfallService;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use App\Services\Constant\CardConstant as Con;
+use App\Services\Constant\GlobalConstant;
 use App\Services\Constant\StockpileHeader as Header;
 
 /**
@@ -18,12 +19,12 @@ class ScryfallController extends Controller
     private $service;
     public function __construct(ScryfallService $service)
     {
-     $this->service = $service;   
+     $this->service = $service;
     }
+
     public function index(ScryfallRequest $request) {
-        $request->input([Header::SETCODE, Con::NUMBER, Header::LANGUAGE]);
-        $card = $this->service->getCardInfoByNumber(
-                $request->input(), $request->input(Con::NUMBER), Header::LANGUAGE);
+        $details = $request->only(GlobalConstant::DATA);
+        $card = $this->service->getCardInfoByNumber($details[GlobalConstant::DATA]);
         return response()->json($card, Response::HTTP_OK);
     }
 }

--- a/app/Http/Requests/ScryfallRequest.php
+++ b/app/Http/Requests/ScryfallRequest.php
@@ -3,6 +3,9 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use App\Services\Constant\StockpileHeader as Header;
+use App\Services\Constant\CardConstant as Con;
+use App\Services\Constant\GlobalConstant;
 
 class ScryfallRequest extends FormRequest
 {
@@ -35,5 +38,11 @@ class ScryfallRequest extends FormRequest
             'setcode' => 'セット略称',
             'number' => 'カード番号',
         ];
+    }
+
+    public function passedValidation()
+    {
+        $info = $this->only([Header::SETCODE, Con::NUMBER, Header::LANGUAGE]);
+        $this->merge([GlobalConstant::DATA => $info]);
     }
 }

--- a/app/Http/Resources/Api/ScryfallResource.php
+++ b/app/Http/Resources/Api/ScryfallResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Resources\Api;
 
+use App\Enum\CardColor;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 use App\Services\Constant\GlobalConstant as GCon;
@@ -22,10 +23,28 @@ class ScryfallResource extends JsonResource
     public function toArray(Request $request): array
     {
         $card = new ScryfallCard($this->resource);
+        $color = CardColor::findColor($card->colors(), $card->types());
+
         return [
             GCon::NAME => $card->name(),
             CCon::EN_NAME => $card->enname(),
             CCon::IMAGE_URL => $card->png(),
-        ];
+            CCon::MULTIVERSEID => $card->multiverseId(),
+            CCon::COLOR => $color->value,
+            // CCon::PROMOTYPE => $card->promotype(),
+            // CCon::NUMBER => $card->number(),
+            // CCon::SETCODE => $card->setcode(),
+            ];
     }
+            // return ['name' => $card->name(),
+            //         'multiverse_id' => $card->multiverseId(),
+            //         'en_name' => $card->enname(),
+            //         'color' => $color->value,
+            //         'promotype'=>$promotype,
+            //         'imageurl' => $card->imageurl(),
+            //         'number' => $card->number(),
+            //         'setcode' => $card->setcode(),
+            //         'reprint' => $card->reprint(),
+            //         'foiltype' => $card->foiltype()
+            // ];
 }

--- a/app/Http/Resources/Api/ScryfallResource.php
+++ b/app/Http/Resources/Api/ScryfallResource.php
@@ -24,27 +24,18 @@ class ScryfallResource extends JsonResource
     {
         $card = new ScryfallCard($this->resource);
         $color = CardColor::findColor($card->colors(), $card->types());
+        $promotype = \App\Facades\Promo::find($card);
 
         return [
+            CCon::SET => $card->setcode(),
             GCon::NAME => $card->name(),
             CCon::EN_NAME => $card->enname(),
             CCon::IMAGE_URL => $card->png(),
             CCon::MULTIVERSEID => $card->multiverseId(),
             CCon::COLOR => $color->value,
-            // CCon::PROMOTYPE => $card->promotype(),
-            // CCon::NUMBER => $card->number(),
-            // CCon::SETCODE => $card->setcode(),
-            ];
+            CCon::PROMOTYPE => $promotype,
+            CCon::NUMBER => $card->number(),
+            CCon::FOIL_TYPE => $card->foiltype()
+        ];
     }
-            // return ['name' => $card->name(),
-            //         'multiverse_id' => $card->multiverseId(),
-            //         'en_name' => $card->enname(),
-            //         'color' => $color->value,
-            //         'promotype'=>$promotype,
-            //         'imageurl' => $card->imageurl(),
-            //         'number' => $card->number(),
-            //         'setcode' => $card->setcode(),
-            //         'reprint' => $card->reprint(),
-            //         'foiltype' => $card->foiltype()
-            // ];
 }

--- a/app/Http/Resources/Api/ScryfallResource.php
+++ b/app/Http/Resources/Api/ScryfallResource.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Resources\Api;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+use App\Services\Constant\GlobalConstant as GCon;
+use App\Services\Constant\CardConstant as CCon;
+use App\Services\json\Scryfall\ScryfallCard;
+
+/**
+ * Scryfall APIから取得したカード情報を整形するResourceクラス
+ * @since  5.2.2
+ */
+class ScryfallResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        $card = new ScryfallCard($this->resource);
+        return [
+            GCon::NAME => $card->name(),
+            CCon::EN_NAME => $card->enname(),
+            CCon::IMAGE_URL => $card->png(),
+        ];
+    }
+}

--- a/app/Providers/ScryfallProvider.php
+++ b/app/Providers/ScryfallProvider.php
@@ -13,7 +13,7 @@ class ScryfallProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->bind('ScryfallServ', 'App\Services\ScryfallService');
+        $this->app->bind('ScryfallServ', 'App\Services\Api\ScryfallService');
     }
 
     /**

--- a/app/Repositories/Api/Mtg/ScryfallRepository.php
+++ b/app/Repositories/Api/Mtg/ScryfallRepository.php
@@ -1,5 +1,7 @@
 <?php
 namespace App\Repositories\Api\Mtg;
+
+use App\Enum\ExternalApi;
 use App\Factory\GuzzleClientFactory;
 use App\Libs\MtgJsonUtil;
 use GuzzleHttp\Exception\ClientException;
@@ -104,7 +106,7 @@ class ScryfallRepository {
     }
 
     private function client() {
-        return GuzzleClientFactory::create('scryfall');
+        return GuzzleClientFactory::createClient(ExternalApi::SCRYFALL);
     }
 }
 ?>

--- a/app/Repositories/Api/Mtg/ScryfallRepository.php
+++ b/app/Repositories/Api/Mtg/ScryfallRepository.php
@@ -4,6 +4,8 @@ use App\Factory\GuzzleClientFactory;
 use App\Libs\MtgJsonUtil;
 use GuzzleHttp\Exception\ClientException;
 use Illuminate\Http\Response;
+use App\Services\Constant\CardConstant as Con;
+use App\Services\Constant\StockpileHeader as Header;
 
 /**
  * scryfall.comのAPI呼び出しクラス
@@ -61,13 +63,15 @@ class ScryfallRepository {
     /**
      * セット略称とカード番号から情報を取得する。
      *
-     * @param string $setCode
-     * @param integer $number
+     * @param array $details リクエストパラメータ
      * @return array
      */
-    public function getCardInfoByNumber(string $setCode, int $number, string $language) {
+    public function getCardInfoByNumber(array $details) {
         $client = $this->client();
-        $rowerCode = \mb_strtolower($setCode);
+        $setcode = $details[Header::SETCODE];
+        $number = $details[Con::NUMBER];
+        $language = $details[Header::LANGUAGE];
+        $rowerCode = \mb_strtolower($setcode);
         $response = $client->request('GET', 'cards/'.$rowerCode.'/'.$number.'/'.$language);
         return $this->getContents($response);
     }

--- a/app/Repositories/Api/Mtg/ScryfallRepository.php
+++ b/app/Repositories/Api/Mtg/ScryfallRepository.php
@@ -1,7 +1,9 @@
 <?php
 namespace App\Repositories\Api\Mtg;
 
+use ApiConnectException;
 use App\Enum\ExternalApi;
+use App\Exceptions\api\NoContentException;
 use App\Factory\GuzzleClientFactory;
 use App\Libs\MtgJsonUtil;
 use GuzzleHttp\Exception\ClientException;
@@ -69,12 +71,24 @@ class ScryfallRepository {
      * @return array
      */
     public function getCardInfoByNumber(array $details) {
-        $client = $this->client();
-        $setcode = $details[Header::SETCODE];
-        $number = $details[Con::NUMBER];
-        $language = $details[Header::LANGUAGE];
-        $rowerCode = \mb_strtolower($setcode);
-        $response = $client->request('GET', 'cards/'.$rowerCode.'/'.$number.'/'.$language);
+        try {
+            $client = $this->client();
+            $setcode = $details[Header::SETCODE];
+            $number = $details[Con::NUMBER];
+            $language = $details[Header::LANGUAGE];
+            $rowerCode = \mb_strtolower($setcode);
+            $response = $client->request('GET', 'cards/'.$rowerCode.'/'.$number.'/'.$language);
+        } catch (ClientException $e) {
+            if ($e->hasResponse()) {
+                $errorResponse = $e->getResponse();
+                $statusCode = $errorResponse->getStatusCode();
+                if ($statusCode == Response::HTTP_NOT_FOUND) {
+                    logger()->error('Not Found in Scryfall');
+                    throw new NoContentException();
+                }
+                throw new ApiConnectException();
+            }
+        }
         return $this->getContents($response);
     }
 

--- a/app/Services/Api/ScryfallService.php
+++ b/app/Services/Api/ScryfallService.php
@@ -1,6 +1,5 @@
 <?php
-namespace App\Services;
-
+namespace App\Services\Api;
 use App\Libs\MtgJsonUtil;
 use App\Repositories\Api\Mtg\ScryfallRepository;
 use App\Enum\CardColor;
@@ -85,7 +84,8 @@ class ScryfallService {
      */
     public function getCardInfoByNumber(array $details) {
         $contents = $this->repo->getCardInfoByNumber($details);
-        return $this->toArray($contents);
+        return $contents;
+        // return $this->toArray($contents);
     }
 
     protected function toArray(array $contents) {

--- a/app/Services/Api/ScryfallService.php
+++ b/app/Services/Api/ScryfallService.php
@@ -4,6 +4,7 @@ use App\Libs\MtgJsonUtil;
 use App\Repositories\Api\Mtg\ScryfallRepository;
 use App\Enum\CardColor;
 use App\Exceptions\api\NotFoundException;
+use App\Factory\CardInfoFactory;
 use App\Services\Constant\CardConstant;
 use App\Services\json\Scryfall\ScryfallCard;
 use App\Services\json\Scryfall\ScryfallTransformCard;
@@ -69,6 +70,13 @@ class ScryfallService {
         return $card->imageurl()['png'];
     }
 
+    /**
+     * @deprecated(version:5.2.2)
+     *
+     * @param string $setcode
+     * @param string $name
+     * @return void
+     */
     public function getCardInfoByName(string $setcode, string $name) {
         $contents = $this->repo->getCardInfoByName($setcode, $name);
         if (empty($contents)) {
@@ -83,12 +91,14 @@ class ScryfallService {
      * @return array
      */
     public function getCardInfoByNumber(array $details) {
-        $contents = $this->repo->getCardInfoByNumber($details);
-        return $contents;
-        // return $this->toArray($contents);
+        $json = $this->repo->getCardInfoByNumber($details);
+        return $json;
     }
 
-    protected function toArray(array $contents) {
+    /**
+     * @deprecated(version: '5.2.2', reason: 'toArrayメソッドはScryfallResourceクラスに移動しました。')
+     */
+    private function toArray(array $contents) {
         $card = new ScryfallCard($contents);
         $color = CardColor::findColor($card->colors(), $card->types());
         $promotype = \App\Facades\Promo::find($card);

--- a/app/Services/ScryfallService.php
+++ b/app/Services/ScryfallService.php
@@ -81,14 +81,10 @@ class ScryfallService {
      * /cards/:code/:numberで情報を取得する。
      *
      * @param array $details
-     * @return void
+     * @return array
      */
     public function getCardInfoByNumber(array $details) {
-        $setcode = $details["setcode"];
-        $number = $details["number"];
-        $language = $details["language"];
-        $contents = $this->repo->getCardInfoByNumber($setcode, $number, $language);
-        // $card = CardInfoFactory::create($contents);
+        $contents = $this->repo->getCardInfoByNumber($details);
         return $this->toArray($contents);
     }
 

--- a/app/Services/json/Scryfall/ScryfallCard.php
+++ b/app/Services/json/Scryfall/ScryfallCard.php
@@ -69,6 +69,11 @@ class ScryfallCard extends AbstractCard {
     }
 
     public function imageurl() {
+        if (MtgJsonUtil::hasKey('card_faces', $this->getJson()) && $this->getJson()['layout'] !== 'split') {
+            $cardFaces = $this->getJson()['card_faces'];
+            $imageuris = $cardFaces[0]['image_uris'];
+            return $imageuris;
+        }
         $imageuris =  $this->getJson()['image_uris'];
         return $imageuris;
     }

--- a/app/Services/json/Scryfall/ScryfallCard.php
+++ b/app/Services/json/Scryfall/ScryfallCard.php
@@ -73,6 +73,11 @@ class ScryfallCard extends AbstractCard {
         return $imageuris;
     }
 
+    public function png() {
+        $imageuris =  $this->imageurl();
+        return $imageuris['png'];
+    }
+
     protected function hasPromotype() {
         return MtgJsonUtil::hasKey('promo_types', $this->getJson());
     }

--- a/app/Services/json/Scryfall/ScryfallCard.php
+++ b/app/Services/json/Scryfall/ScryfallCard.php
@@ -4,7 +4,7 @@ namespace App\Services\json\Scryfall;
 use App\Libs\MtgJsonUtil;
 use App\Services\json\AbstractCard;
 use App\Services\Constant\CardConstant as Con;
-
+use App\Services\Constant\GlobalConstant as GCon;
 
 class ScryfallCard extends AbstractCard {
 
@@ -37,7 +37,7 @@ class ScryfallCard extends AbstractCard {
      * @return string
      */
     public function enname():string {
-        return $this->getJson()[Con::NAME];
+        return $this->getJson()[GCon::NAME];
     }
 
     /**
@@ -73,6 +73,11 @@ class ScryfallCard extends AbstractCard {
         return $imageuris;
     }
 
+    /**
+     * png画像のURLを取得する。
+     *
+     * @return string
+     */
     public function png() {
         $imageuris =  $this->imageurl();
         return $imageuris['png'];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
-    "version": "5.2.1",
+    "version": "5.2.2",
     "scripts": {
         "dev": "vite --host",
         "build": "vite build",

--- a/resources/js/pages/config/CardInfoPage.vue
+++ b/resources/js/pages/config/CardInfoPage.vue
@@ -162,16 +162,17 @@ export default {
                     let data = response.data;
                     this.name = data["name"];
                     this.en_name = data["en_name"];
-                    this.multiverse_id = data["multiverse_id"];
+                    this.multiverse_id = data["multiverseId"];
                     this.color = data["color"];
-                    this.imageurl = data["imageurl"]["png"];
+                    this.imageurl = data["image_url"];
                     this.foiltype = data["foiltype"];
                 })
                 .catch((e) => {
+                    console.log(e);
                     if (e.response.status != 200) {
                         this.$store.dispatch(
                             "message/error",
-                            "カード情報がありません。"
+                            e.response.data.detail
                         );
                     }
                 })

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,11 +1,11 @@
 <?php
 
+use App\Http\Controllers\Api\ScryfallController;
 use App\Http\Controllers\DB\ExpDBController;
 use App\Http\Controllers\Notion\CardController;
 use App\Http\Controllers\Notion\ExpansionController;
 use App\Http\Controllers\CardJsonFileController;
 use App\Http\Controllers\DB\CardInfoDBController;
-use App\Http\Controllers\ScryfallController;
 use App\Http\Controllers\StockpileController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;

--- a/tests/Trait/ApiErrorAssertions.php
+++ b/tests/Trait/ApiErrorAssertions.php
@@ -33,4 +33,15 @@ trait ApiErrorAssertions {
         });
     }
 
+    public function assertApiError(TestResponse $response, string $endpoint, string $title, string $detail, int $status) {
+        $response->assertJson(function(AssertableJson $json) use($endpoint, $title, $detail, $status) {
+            $json->hasAll([EC::TITLE, GC::STATUS, EC::REQUEST, EC::DETAIL]);
+            $json->whereAll([
+                EC::TITLE => $title,
+                EC::DETAIL => $detail,
+                GC::STATUS => $status,
+                EC::REQUEST => $endpoint,
+            ]);
+        });
+    }
 }

--- a/tests/Unit/DB/Card/CardInfoDBTest.php
+++ b/tests/Unit/DB/Card/CardInfoDBTest.php
@@ -49,6 +49,7 @@ class CardInfoDBTest extends TestCase
  * @return void
  */
     #[DataProvider('imageprovider')]
+    #[TestDox('画像URLの取得に関する検証')]
     public function test_getImage(string $setcode, int $multiId, string $scryId) {
         $name = fake()->realText(10);
         $params = $this->createParams($setcode, $name, 1, ['通常版']);

--- a/tests/Unit/Scryfall/ScryfallTest.php
+++ b/tests/Unit/Scryfall/ScryfallTest.php
@@ -2,17 +2,18 @@
 
 namespace Tests\Feature;
 
+use App\Http\Controllers\ScryfallController;
 use App\Services\Constant\CardConstant as Con;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 use App\Services\Constant\GlobalConstant as GCon;
 use App\Services\Constant\StockpileHeader as Header;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversMethod;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * ScryfallControllerのテスト
- */
+#[CoversMethod(ScryfallController::class, 'index')]
 class ScryfallTest extends TestCase
 {
     /**

--- a/tests/Unit/Scryfall/ScryfallTest.php
+++ b/tests/Unit/Scryfall/ScryfallTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Api\Client\ScryfallClient;
+use App\Enum\CardColor;
 use App\Enum\ExternalApi;
 use App\Http\Controllers\ScryfallController;
 use App\Services\Constant\CardConstant as Con;
@@ -15,24 +16,65 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversMethod;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\Attributes\TestWith;
 
+#[TestDox('エンドポイントが"api/scryfall"のテストクラス')]
 #[CoversMethod(ScryfallController::class, 'index')]
 class ScryfallTest extends TestCase
 {
     #[Test]
-    #[TestWith(["ja", '辺境地の御目付役、アジャニ', 'https://cards.scryfall.io/png/front/8/a/8afd2b17-a53f-421a-a61e-2957973cf860.png?1770090933'], '日本語')]
-    #[TestWith(["en", '', 'https://cards.scryfall.io/png/front/6/1/6124a691-ae83-4d22-a177-0aee65b47064.png?1767951721'], '英語')]
+    #[TestDox('言語を指定してカード情報が取得できることを検証する')]
+    #[TestWith(["ja", '辺境地の御目付役、アジャニ', '8/a/8afd2b17-a53f-421a-a61e-2957973cf860.png?1770090933'], '日本語')]
+    #[TestWith(["en", '', '6/1/6124a691-ae83-4d22-a177-0aee65b47064.png?1767951721'], '英語')]
     public function 言語を指定(string $lang, string $jpname, string $imageUrl) {
         $response = $this->ok('ECL', '4', $lang);
         $response->assertJson(function ($json) use ($jpname, $imageUrl) {
             $json->whereAll([
                 GCon::NAME => $jpname,
                 Con::EN_NAME => 'Ajani, Outland Chaperone',
-                Con::IMAGE_URL => $imageUrl,
+                Con::IMAGE_URL => 'https://cards.scryfall.io/png/front/'.$imageUrl,
             ]);
         });
     }
+
+    #[Test]
+    #[TestWith(['ECL', '4', 0], 'multiverseidなし')]
+    #[TestWith(['WAR', '272', 463894], 'multiverseidあり')]
+    #[TestDox('レスポンスのmultiverseIdの有無を検証する')]
+    public function multiverseId(string $setcode, string $number, int $multiverseId) {
+        $response = $this->ok($setcode, $number, 'ja');
+        $response->assertJsonPath(Con::MULTIVERSEID, $multiverseId);
+    }
+
+    #[Test]
+    #[TestWith(['1', CardColor::LESS], '無色')]
+    #[TestWith(['4', CardColor::WHITE], '白')]
+    #[TestWith(['46', CardColor::BLUE], '青')]
+    #[TestWith(['88', CardColor::BLACK], '黒')]
+    #[TestWith(['159', CardColor::RED], '赤')]
+    #[TestWith(['86', CardColor::BLACK], '色付きアーティファクト')]
+    #[TestWith(['164', CardColor::GREEN], '緑')]
+    #[TestWith(['209', CardColor::MULTI], '多色')]
+    #[TestWith(['253', CardColor::ARTIFACT], '伝説のアーティファクト')]
+    #[TestWith(['254', CardColor::ARTIFACT], '色無しアーティファクト')]
+    #[TestWith(['262', CardColor::LAND], '二色土地')]
+    #[TestWith(['264', CardColor::LAND], '無色土地')]
+    #[TestWith(['269', CardColor::LAND], '基本土地')]
+    #[TestDox('レスポンスのcolorの有無を検証する')]
+    public function color(string $number, CardColor $excolor) {
+        $response = $this->ok('ECL', $number, 'en');
+        $response->assertJsonPath(Con::COLOR, $excolor->value);
+    }
+
+     /**
+     * 画像URLが正しいことを検証する。
+     *
+     * @param string $setcode
+     * @param int $number
+     * @param string $url
+     * @return void
+     */
 
     /**
      * A basic feature test example.

--- a/tests/Unit/Scryfall/ScryfallTest.php
+++ b/tests/Unit/Scryfall/ScryfallTest.php
@@ -2,17 +2,12 @@
 
 namespace Tests\Feature;
 
-use App\Api\Client\ScryfallClient;
 use App\Enum\CardColor;
-use App\Enum\ExternalApi;
 use App\Http\Controllers\ScryfallController;
 use App\Services\Constant\CardConstant as Con;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 use App\Services\Constant\GlobalConstant as GCon;
 use App\Services\Constant\StockpileHeader as Header;
-use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversMethod;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
@@ -20,12 +15,14 @@ use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\Attributes\TestWith;
 use Tests\Database\Seeders\DatabaseSeeder;
 use Tests\Database\Seeders\TruncateAllTables;
+use Tests\Trait\ApiErrorAssertions;
 
 #[TestDox('エンドポイントが"api/scryfall"のテストクラス')]
 #[CoversMethod(ScryfallController::class, 'index')]
 class ScryfallTest extends TestCase
 {
 
+    use ApiErrorAssertions;
     public function setUp(): void
     {
         parent::setUp();
@@ -118,6 +115,15 @@ class ScryfallTest extends TestCase
             '上下二面カード' => ['AKH', 210, '4/c/4cffc5c9-0115-4a8f-9665-a3fbdd4179c2.png?1540281378'],
             '表裏両面カード' => ['MH3', 261, '3/0/305ae3b5-7c12-43ad-b19f-dbd04c9afcf7.png?1730229671'],
         ];
+    }
+
+    #[Test]
+    #[TestDox('存在しないカード情報をリクエストした場合、404エラーが返ることを検証する。')]
+    public function nocardinfo()
+    {
+        $query = [Header::SETCODE => 'ECL', Con::NUMBER => '9999', Header::LANGUAGE => 'ja'];
+        $response = $this->call('GET', '/api/scryfall', $query);
+        $this->assertApiError($response, 'api/scryfall', '情報なし', '指定した情報がありません。', 404);
     }
 
     public function ok(string $setcode, string $number, string $lang)

--- a/tests/Unit/Scryfall/ScryfallTest.php
+++ b/tests/Unit/Scryfall/ScryfallTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Feature;
 
+use App\Api\Client\ScryfallClient;
+use App\Enum\ExternalApi;
 use App\Http\Controllers\ScryfallController;
 use App\Services\Constant\CardConstant as Con;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -12,10 +14,26 @@ use App\Services\Constant\StockpileHeader as Header;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversMethod;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestWith;
 
 #[CoversMethod(ScryfallController::class, 'index')]
 class ScryfallTest extends TestCase
 {
+    #[Test]
+    #[TestWith(["ja", '辺境地の御目付役、アジャニ', 'https://cards.scryfall.io/png/front/8/a/8afd2b17-a53f-421a-a61e-2957973cf860.png?1770090933'], '日本語')]
+    #[TestWith(["en", '', 'https://cards.scryfall.io/png/front/6/1/6124a691-ae83-4d22-a177-0aee65b47064.png?1767951721'], '英語')]
+    public function 言語を指定(string $lang, string $jpname, string $imageUrl) {
+        $response = $this->ok('ECL', '4', $lang);
+        $response->assertJson(function ($json) use ($jpname, $imageUrl) {
+            $json->whereAll([
+                GCon::NAME => $jpname,
+                Con::EN_NAME => 'Ajani, Outland Chaperone',
+                Con::IMAGE_URL => $imageUrl,
+            ]);
+        });
+    }
+
     /**
      * A basic feature test example.
      */
@@ -35,5 +53,13 @@ class ScryfallTest extends TestCase
             '上下二面カード' => ['AKH', 210, 'https://cards.scryfall.io/png/front/4/c/4cffc5c9-0115-4a8f-9665-a3fbdd4179c2.png?1540281378'],
             '表裏両面カード' => ['MH3', 261, 'https://cards.scryfall.io/png/front/3/0/305ae3b5-7c12-43ad-b19f-dbd04c9afcf7.png?1730229671'],
         ];
+    }
+
+    public function ok(string $setcode, string $number, string $lang)
+    {
+        $query = [Header::SETCODE => $setcode, Con::NUMBER => $number, Header::LANGUAGE => $lang];
+        $response = $this->call('GET', '/api/scryfall', $query);
+        $response->assertOk();
+        return $response;
     }
 }

--- a/tests/Unit/Scryfall/ScryfallTest.php
+++ b/tests/Unit/Scryfall/ScryfallTest.php
@@ -18,24 +18,34 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\Attributes\TestWith;
+use Tests\Database\Seeders\DatabaseSeeder;
+use Tests\Database\Seeders\TruncateAllTables;
 
 #[TestDox('エンドポイントが"api/scryfall"のテストクラス')]
 #[CoversMethod(ScryfallController::class, 'index')]
 class ScryfallTest extends TestCase
 {
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(TruncateAllTables::class);
+        $this->seed(DatabaseSeeder::class);
+    }
+
     #[Test]
     #[TestDox('言語を指定してカード情報が取得できることを検証する')]
     #[TestWith(["ja", '辺境地の御目付役、アジャニ', '8/a/8afd2b17-a53f-421a-a61e-2957973cf860.png?1770090933'], '日本語')]
     #[TestWith(["en", '', '6/1/6124a691-ae83-4d22-a177-0aee65b47064.png?1767951721'], '英語')]
     public function 言語を指定(string $lang, string $jpname, string $imageUrl) {
         $response = $this->ok('ECL', '4', $lang);
-        $response->assertJson(function ($json) use ($jpname, $imageUrl) {
-            $json->whereAll([
-                GCon::NAME => $jpname,
-                Con::EN_NAME => 'Ajani, Outland Chaperone',
-                Con::IMAGE_URL => 'https://cards.scryfall.io/png/front/'.$imageUrl,
-            ]);
-        });
+        $response->assertJson([
+            Con::SET => 'ECL',
+            GCon::NAME => $jpname,
+            Con::EN_NAME => 'Ajani, Outland Chaperone',
+            Con::IMAGE_URL => $this->createImageUrl($imageUrl),
+            Con::NUMBER => '4',
+        ]);
     }
 
     #[Test]
@@ -67,6 +77,21 @@ class ScryfallTest extends TestCase
         $response->assertJsonPath(Con::COLOR, $excolor->value);
     }
 
+    #[Test]
+    #[TestDox('レスポンスにpromotypeが存在するか検証する。')]
+     public function promotype() {
+        $response = $this->ok('EOE', '1', 'en');
+        $response->assertJsonPath(Con::PROMOTYPE, 1);
+     }
+
+    #[Test]
+    #[TestWith(['ONE', '1', ['通常版', 'Foil']], '通常版')]
+    #[TestWith(['STA', '125', ['通常版', 'Foil', 'エッチングFoil']], '特殊Foil')]
+    #[TestDox('レスポンスにfoiltypeが存在するか検証する。')]
+     public function foiltype(string $setcode, string $number, array $foiltypes) {
+        $response = $this->ok($setcode, $number, 'ja');
+        $response->assertJsonPath(Con::FOIL_TYPE, $foiltypes);
+     }
      /**
      * 画像URLが正しいことを検証する。
      *
@@ -75,25 +100,23 @@ class ScryfallTest extends TestCase
      * @param string $url
      * @return void
      */
-
-    /**
-     * A basic feature test example.
-     */
+    #[Test]
     #[DataProvider('imageProvider')]
-    public function test_画像(string $setcode, int $number, string $url): void
+    #[TestDox('レスポンスの画像URLが正しいことを検証する。')]
+    public function imageurl(string $setcode, int $number, string $url): void
     {
         $query = [Header::SETCODE => $setcode, Con::NUMBER => $number, Header::LANGUAGE => 'ja'];
         $response = $this->call('GET', '/api/scryfall', $query);
         $response->assertOk();
-        $response->assertJsonFragment(['imageurl' => $url]);
+        $response->assertJsonPath(Con::IMAGE_URL, $this->createImageUrl($url));
     }
 
     public static function imageProvider(): array
     {
         return [
-            '表面のみ' => ['IKO', 1, 'https://cards.scryfall.io/png/front/e/1/e1059d5b-1de6-4988-a3a8-fe540a541342.png?1645734158'],
-            '上下二面カード' => ['AKH', 210, 'https://cards.scryfall.io/png/front/4/c/4cffc5c9-0115-4a8f-9665-a3fbdd4179c2.png?1540281378'],
-            '表裏両面カード' => ['MH3', 261, 'https://cards.scryfall.io/png/front/3/0/305ae3b5-7c12-43ad-b19f-dbd04c9afcf7.png?1730229671'],
+            '表面のみ' => ['IKO', 1, 'e/1/e1059d5b-1de6-4988-a3a8-fe540a541342.png?1645734158'],
+            '上下二面カード' => ['AKH', 210, '4/c/4cffc5c9-0115-4a8f-9665-a3fbdd4179c2.png?1540281378'],
+            '表裏両面カード' => ['MH3', 261, '3/0/305ae3b5-7c12-43ad-b19f-dbd04c9afcf7.png?1730229671'],
         ];
     }
 
@@ -103,5 +126,16 @@ class ScryfallTest extends TestCase
         $response = $this->call('GET', '/api/scryfall', $query);
         $response->assertOk();
         return $response;
+    }
+
+    /**
+     * 期待値の画像URLを作成する。
+     *
+     * @param string $png
+     * @return string 画像URL
+     */
+    private function createImageUrl(string $png): string
+    {
+        return 'https://cards.scryfall.io/png/front/' . $png;
     }
 }


### PR DESCRIPTION
## 概要

Scryfall APIの仕様変更により連携できなくなった不具合を修正。

## 変更点

- AbstractApiClient.php:外部APIとの連携設定を書いた抽象クラスを追加。
- ScryfallClient.php:Scryfall APIとの連携設定を書いたクラスを追加。
- ExternalApi.php 各外部APIのenumクラスを追加。
- GuzzleClientFactory.php 各外部APIとの連携オブジェクトの作成方法を変更。

## 影響範囲

外部APIの接続に関するテストは行いましたが、各外部APIへの接続の仕組みを一部変更したため他APIとの連携に問題が出るかもしれません。

## ユニットテスト

- ScryfallTest.php:Scryfall APIとの接続テスト
- CardInfoDBTest.php:カード情報の登録テスト

## 関連Issue
なし。