### PR TITLE
#293：カード情報登録：「荒地」が登録できない不具合を修正。

### DIFF
--- a/app/Services/json/BasicLand.php
+++ b/app/Services/json/BasicLand.php
@@ -7,7 +7,8 @@ class BasicLand extends JsonCard
 {
     public function jpname(string $enname):string
     {
-        $names = ["Island" => "島", "Plains" => "平地", "Swamp" => "沼", "Forest" => "森", "Mountain" => "山"];
+        $names = ["Island" => "島", "Plains" => "平地", "Swamp" => "沼",
+                             "Forest" => "森", "Mountain" => "山",  "Wastes" => "荒地"];
         return $names[$enname].'('.$this->number().')';
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
-    "version": "5.2.3",
+    "version": "5.2.4",
     "scripts": {
         "dev": "vite --host",
         "build": "vite build",


### PR DESCRIPTION
## 概要

基本土地カード「荒地」が登録できない不具合を修正。

## 変更点

このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。

- BasicLand.php

## 影響範囲

なし。

## ユニットテスト

なし。

fix #293 