### PR TITLE
Feature/289：BASE API連携ステータス確認APIの実装

### DIFF
--- a/app/Http/Controllers/Baseshop/BaseOAuthController.php
+++ b/app/Http/Controllers/Baseshop/BaseOAuthController.php
@@ -44,7 +44,7 @@ class BaseOAuthController extends Controller
     public function callback(BaseCallbackRequest $request)
     {
         $code = $request->input(BCon::AUTH_CODE);
-        $isConnected = $this->service->registerToken($code);
+        $isConnected = $this->service->registToken($code);
         return response()->json([BCon::CONNECTED => $isConnected], Response::HTTP_CREATED);
     }
 
@@ -55,6 +55,7 @@ class BaseOAuthController extends Controller
      */
     public function status()
     {
-        return response()->json([BCon::CONNECTED => true], Response::HTTP_OK);
+        $isConnected = $this->service->isConnected();
+        return response()->json([BCon::CONNECTED => $isConnected], Response::HTTP_OK);
     }
 }

--- a/app/Http/Controllers/Baseshop/BaseOAuthController.php
+++ b/app/Http/Controllers/Baseshop/BaseOAuthController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers\Baseshop;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Auth\BaseCallbackRequest;
-use App\Services\Baseshop\BaseApiService;
+use App\Services\Baseshop\BaseOAuthService;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
 use App\Services\Constant\BaseApiConstant as BCon;
@@ -17,7 +17,7 @@ class BaseOAuthController extends Controller
 
     private $service;
 
-    public function __construct(BaseApiService $service)
+    public function __construct(BaseOAuthService $service)
     {
         $this->service = $service;
     }

--- a/app/Http/Controllers/Baseshop/BaseOAuthController.php
+++ b/app/Http/Controllers/Baseshop/BaseOAuthController.php
@@ -16,6 +16,7 @@ class BaseOAuthController extends Controller
 {
 
     private $service;
+
     public function __construct(BaseApiService $service)
     {
         $this->service = $service;
@@ -44,7 +45,7 @@ class BaseOAuthController extends Controller
     {
         $code = $request->input(BCon::AUTH_CODE);
         $isConnected = $this->service->registerToken($code);
-        return response()->json(['connected' => $isConnected], Response::HTTP_CREATED);
+        return response()->json([BCon::CONNECTED => $isConnected], Response::HTTP_CREATED);
     }
 
     /**
@@ -54,6 +55,6 @@ class BaseOAuthController extends Controller
      */
     public function status()
     {
-
+        return response()->json([BCon::CONNECTED => true], Response::HTTP_OK);
     }
 }

--- a/app/Models/BaseToken.php
+++ b/app/Models/BaseToken.php
@@ -14,13 +14,13 @@ class BaseToken extends Model
     protected $fillable = [
         'access_token',
         'refresh_token',
-        'expires_at',
+        'expires_in',
     ];
 
     // 暗号化
     protected $casts = [
         'access_token' => 'encrypted',
         'refresh_token' => 'encrypted',
-        'expires_at' => 'datetime',
+        'expires_in' => 'datetime',
     ];
 }

--- a/app/Models/BaseToken.php
+++ b/app/Models/BaseToken.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Services\Constant\BaseApiConstant;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
@@ -23,4 +24,13 @@ class BaseToken extends Model
         'refresh_token' => 'encrypted',
         'expires_in' => 'datetime',
     ];
+
+    /**
+     * 有効期限が最新のレコードを1件取得する。
+     *
+     * @return BaseToken
+     */
+    public static function fetchLastRecord() {
+        return self::latest(BaseApiConstant::EXPIRES_IN)->first();
+    }
 }

--- a/app/Repositories/Api/Baseshop/BaseApiRepository.php
+++ b/app/Repositories/Api/Baseshop/BaseApiRepository.php
@@ -7,6 +7,7 @@ use App\Exceptions\api\Baseshop\BaseApiException;
 use App\Factory\GuzzleClientFactory;
 use App\Models\BaseToken;
 use GuzzleHttp\Exception\RequestException;
+use App\Services\Constant\BaseApiConstant as BCon;
 
 /**
  * BASE APIとの連携クラス
@@ -53,9 +54,9 @@ class BaseApiRepository
     public function registToken(array $tokens)
     {
         BaseToken::create([
-            'access_token' => $tokens['access_token'],
-            'refresh_token' => $tokens['refresh_token'],
-            'expires_at' => now()->addSeconds($tokens['expires_in'])
+            BCon::ACCESS_TOKEN => $tokens[BCon::ACCESS_TOKEN],
+            BCon::REFRESH_TOKEN => $tokens[BCon::REFRESH_TOKEN],
+            BCon::EXPIRES_IN => now()->addSeconds($tokens[BCon::EXPIRES_IN])
         ]);
     }
 }

--- a/app/Repositories/Api/Baseshop/BaseOAuthRepository.php
+++ b/app/Repositories/Api/Baseshop/BaseOAuthRepository.php
@@ -23,16 +23,36 @@ class BaseOAuthRepository
      */
     public function getAccessToken(string $code):array
     {
+        $params = $this->getClientInfo('authorization_code');
+        $params['code'] = $code;
+        return $this->getToken($params);
+    }
+
+    /**
+     * アクセストークンを再発行する。
+     *
+     * @param string $refreshToken
+     * @return array
+     */
+    public function refreshAccessToken(string $refreshToken):array
+    {
+        $params = $this->getClientInfo('refresh_token');
+        $params['refresh_token'] = $refreshToken;
+        return $this->getToken($params);
+    }
+
+    /**
+     * リクエストパラメータをもとに
+     * アクセストークンとリフレッシュトークンを取得する。
+     *
+     * @param array $params リクエストパラメータ
+     * @return array
+     */
+    private function getToken(array $params) {
         try {
             $client = GuzzleClientFactory::createClient(ExternalApi::BASE);
             $response = $client->post('/1/oauth/token', [
-                'form_params' => [
-                    'grant_type'    => 'authorization_code',
-                    'client_id'     => config('baseapi.client_id'),
-                    'client_secret' => config('baseapi.secret'),
-                    'code'          => $code,
-                    'redirect_uri'  => config('baseapi.api_url'),
-                ],
+                'form_params' => $params,
             ]);
 
             return json_decode($response->getBody()->getContents(), true);
@@ -46,6 +66,22 @@ class BaseOAuthRepository
     }
 
     /**
+     * アクセストークン取得に必要なリクエストパラメータを取得する。
+     *
+     * @param string $grantType
+     * @return array リクエストパラメータ
+     */
+    private function getClientInfo(string $grantType):array {
+        $params = [
+                'grant_type'    => $grantType,
+                'client_id'     => config('baseapi.client_id'),
+                'client_secret' => config('baseapi.secret'),
+                'redirect_uri'  => config('baseapi.api_url'),
+            ];
+        return $params;
+    }
+
+    /**
      * BASE APIのトークンを登録する。
      *
      * @param array $tokens
@@ -54,6 +90,21 @@ class BaseOAuthRepository
     public function registToken(array $tokens)
     {
         BaseToken::create([
+            BCon::ACCESS_TOKEN => $tokens[BCon::ACCESS_TOKEN],
+            BCon::REFRESH_TOKEN => $tokens[BCon::REFRESH_TOKEN],
+            BCon::EXPIRES_IN => now()->addSeconds($tokens[BCon::EXPIRES_IN])
+        ]);
+    }
+
+    /**
+     * BASE APIのトークンを更新する。
+     *
+     * @param BaseToken $record
+     * @param array $tokens
+     * @return void
+     */
+    public function updateToken(BaseToken $record, array $tokens) {
+        $record->update([
             BCon::ACCESS_TOKEN => $tokens[BCon::ACCESS_TOKEN],
             BCon::REFRESH_TOKEN => $tokens[BCon::REFRESH_TOKEN],
             BCon::EXPIRES_IN => now()->addSeconds($tokens[BCon::EXPIRES_IN])

--- a/app/Repositories/Api/Baseshop/BaseOAuthRepository.php
+++ b/app/Repositories/Api/Baseshop/BaseOAuthRepository.php
@@ -10,9 +10,9 @@ use GuzzleHttp\Exception\RequestException;
 use App\Services\Constant\BaseApiConstant as BCon;
 
 /**
- * BASE APIとの連携クラス
+ * BASE APIの認証関連のリポジトリクラス
  */
-class BaseApiRepository
+class BaseOAuthRepository
 {
 
     /**

--- a/app/Repositories/Api/Baseshop/BaseOAuthRepository.php
+++ b/app/Repositories/Api/Baseshop/BaseOAuthRepository.php
@@ -59,4 +59,14 @@ class BaseOAuthRepository
             BCon::EXPIRES_IN => now()->addSeconds($tokens[BCon::EXPIRES_IN])
         ]);
     }
+
+    /**
+     * 有効期限が最新のアクセストークンを1件取得する。
+     *
+     * @return BaseToken
+     */
+    public function getLatestToken() {
+        $record = BaseToken::fetchLastRecord();
+        return $record;
+    }
 }

--- a/app/Services/Baseshop/BaseOAuthService.php
+++ b/app/Services/Baseshop/BaseOAuthService.php
@@ -38,6 +38,10 @@ class BaseOAuthService
      */
     public function isConnected() {
         $record = $this->repo->getLatestToken();
+        // トークンが未登録の場合は連携していないとみなす。
+        if (!$record) {
+            return false;
+        }
         $now = CarbonImmutable::now();
         $diff = $record->expires_in->diffInMinutes($now);
 
@@ -45,7 +49,10 @@ class BaseOAuthService
             return true;
         }
 
-        return false;
+        $refreshToken = $record->refresh_token;
+        $tokens = $this->repo->refreshAccessToken($refreshToken);
+        $this->repo->updateToken($record, $tokens);
+        return true;
     }
 
     public function fetchOrders(string $accessToken, array $query = [])

--- a/app/Services/Baseshop/BaseOAuthService.php
+++ b/app/Services/Baseshop/BaseOAuthService.php
@@ -3,6 +3,7 @@
 namespace App\Services\Baseshop;
 
 use App\Repositories\Api\Baseshop\BaseOAuthRepository;
+use Carbon\CarbonImmutable;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\RequestException;
 
@@ -22,12 +23,29 @@ class BaseOAuthService
      * @param string $code
      * @return void
      */
-    public function registerToken(string $code) {
+    public function registToken(string $code) {
         $tokens = $this->repo->getAccessToken($code);
         logger()->debug('取得したトークン', $tokens);
         // トークンをDBに保存する処理をここに追加
         $this->repo->registToken($tokens);
         return true;
+    }
+
+    /**
+     * BASE APIと連携済みか検証する。
+     *
+     * @return boolean
+     */
+    public function isConnected() {
+        $record = $this->repo->getLatestToken();
+        $now = CarbonImmutable::now();
+        $diff = $record->expires_in->diffInMinutes($now);
+
+        if ($diff <= 60) {
+            return true;
+        }
+
+        return false;
     }
 
     public function fetchOrders(string $accessToken, array $query = [])

--- a/app/Services/Baseshop/BaseOAuthService.php
+++ b/app/Services/Baseshop/BaseOAuthService.php
@@ -11,7 +11,7 @@ class BaseOAuthService
 {
     protected Client $client;
 
-    private $repo;
+    private BaseOAuthRepository $repo;
     public function __construct(BaseOAuthRepository $repo)
     {
         $this->repo = $repo;
@@ -49,6 +49,7 @@ class BaseOAuthService
             return true;
         }
 
+        logger()->info('アクセストークン再発行');
         $refreshToken = $record->refresh_token;
         $tokens = $this->repo->refreshAccessToken($refreshToken);
         $this->repo->updateToken($record, $tokens);

--- a/app/Services/Baseshop/BaseOAuthService.php
+++ b/app/Services/Baseshop/BaseOAuthService.php
@@ -2,17 +2,16 @@
 
 namespace App\Services\Baseshop;
 
-use App\Repositories\Api\Baseshop\BaseApiRepository;
-use App\Repositories\Api\Baseshop\BaseApiRepositoryInterface;
+use App\Repositories\Api\Baseshop\BaseOAuthRepository;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\RequestException;
 
-class BaseApiService
+class BaseOAuthService
 {
     protected Client $client;
 
     private $repo;
-    public function __construct(BaseApiRepository $repo)
+    public function __construct(BaseOAuthRepository $repo)
     {
         $this->repo = $repo;
     }

--- a/app/Services/Constant/BaseApiConstant.php
+++ b/app/Services/Constant/BaseApiConstant.php
@@ -8,5 +8,14 @@ namespace App\Services\Constant;
 class BaseApiConstant
 {
     public const AUTH_CODE = 'code';
+
+    public const CONNECTED = 'connected';
+
+    public const ACCESS_TOKEN = 'access_token';
+
+    public const REFRESH_TOKEN = 'refresh_token';
+
+    public const EXPIRES_IN = 'expires_in';
+
 }
 

--- a/database/migrations/2026_04_20_094302_create_base_token.php
+++ b/database/migrations/2026_04_20_094302_create_base_token.php
@@ -15,7 +15,7 @@ return new class extends Migration
             $table->id();
             $table->text('access_token')->comment('アクセストークン')->notNull();
             $table->text('refresh_token')->comment('リフレッシュトークン')->notNull();
-            $table->dateTime('expires_at')->comment('有効期限')->notNull();
+            $table->dateTime('expires_in')->comment('有効期限')->notNull();
             $table->timestamps();
         });
     }

--- a/resources/js/auth/auth-guard.js
+++ b/resources/js/auth/auth-guard.js
@@ -1,35 +1,52 @@
 import{ store} from '@/store';
 import {baseConnected } from "@/stores/auth/baseConnected";
+import {LoadingStore} from '@/stores/loading/Loading';
+import axios from 'axios';
 import { storeToRefs } from 'pinia';
 
 // 認証に関するスクリプト
 export const authGuard = (router) => {
 
-    router.beforeEach((to, from, next) => {
+    router.beforeEach(async(to, from, next) => {
+            const loading  = LoadingStore();
             router['referrer'] = from;
-            store.dispatch("loading/start");
+
+            loading.start();
             // BASE API認証
             const requiresBase = to.meta?.requiresBase ?? false;
-            if (!requiresBase) {
+            const baseStore = baseConnected();
+            if (!requiresBase || baseStore.hasConnected()) {
                 return next();
             }
 
-            const baseStore = baseConnected();
-            const {isConnected, expiresAt} = storeToRefs(baseStore);
-
-            if (!isConnected.value) {
-                return next({
-                                path: "/base/auth/",
-                                query: {
-                                    redirect: to.fullPath
-                                }
-                            });
-            }
-            next();
-    });
+            await axios.get('/api/base/oauth/status')
+                .then((response) => {
+                    const isConnected = response.data.connected;
+                    if (isConnected) {
+                        baseStore.connect();
+                        return next();
+                    } else {
+                        return next({
+                                        path: "/base/auth/",
+                                        query: {
+                                            redirect: to.fullPath
+                                        }
+                                    });
+                    }
+                })
+                .catch(() => {
+                    return next({
+                                    path: "/base/auth/",
+                                    query: {
+                                        redirect: to.fullPath
+                                    }
+                                });
+                })
+            });
 
     router.afterEach(() => {
-        store.dispatch("loading/stop");
+        const loading  = LoadingStore();
+        loading.stop();
     });
 
 };

--- a/resources/js/layout/DefaultLayout.vue
+++ b/resources/js/layout/DefaultLayout.vue
@@ -1,125 +1,159 @@
 <script setup>
-import SideMenu from "../pages/component/SideMenu.vue";
-import Loading from "vue-loading-overlay";
+import { ref, onMounted, watch, nextTick, computed } from 'vue'
+import { useRoute } from 'vue-router'
+import SideMenu from "../pages/component/SideMenu.vue"
+import Loading from "vue-loading-overlay"
+import "vue-loading-overlay/dist/css/index.css"
 
+import { LoadingStore } from '@/stores/loading/Loading'
+import { storeToRefs } from "pinia"
+
+// ----------------------
+// store
+// ----------------------
+const loadingStore = LoadingStore()
+const { isLoading } = storeToRefs(loadingStore)
+
+// ----------------------
+// route
+// ----------------------
+const route = useRoute()
+
+// ----------------------
+// DOM refs
+// ----------------------
+const sidebar = ref(null)
+const main = ref(null)
+
+// ----------------------
+// layout state
+// ----------------------
+const initHeight = ref(0)
+const sidebarHeight = ref(0)
+const mainHeight = ref(0)
+const isMounted = ref(false)
+
+// ----------------------
+// computed
+// ----------------------
+const higherHeightPx = computed(() => {
+  return isMounted.value
+    ? Math.max(sidebarHeight.value, mainHeight.value) + "px"
+    : null
+})
+
+// ----------------------
+// route watch（旧watch置き換え）
+// ----------------------
+watch(route, () => {
+  // Vuex使ってるならそのまま
+  // ※ ここはPiniaに寄せた方がいい
+  // store.dispatch("clearCards")
+  // store.dispatch("clearMessage")
+
+  mainHeight.value = initHeight.value
+})
+
+// ----------------------
+// mounted処理
+// ----------------------
+onMounted(() => {
+  nextTick(() => {
+    if (!main.value) return
+
+    const resizeObserver = new ResizeObserver(() => {
+      mainHeight.value = main.value.clientHeight
+    })
+
+    resizeObserver.observe(main.value)
+
+    sidebarHeight.value = sidebar.value?.clientHeight || 0
+    mainHeight.value = main.value.clientHeight
+    initHeight.value = mainHeight.value
+
+    isMounted.value = true
+  })
+})
 </script>
+
 <template>
-    <header>
-        <div class="ui pointing menu">
-            <div class="header navbar-brand">
-                <router-link to="/" class="navbar-brand"
-                    ><i class="bi bi-gem"></i> SPARKCARD</router-link
-                >
-            </div>
-            <div class="right menu">
-                <router-link
-                    to="/config/expansion"
-                    class="item"
-                    :class="{
-                        active: $route.path === '/config/expansion',
-                    }"
-                    ><i class="cogs icon"></i>マスタ設定</router-link
-                >
-            </div>
-        </div>
-    </header>
-    <div id="contents" class="ui grid padded">
-        <nav
-            ref="sidebar"
-            class="three wide column blue"
-            :style="{ height: higherHeightPx }"
-        >
-            <SideMenu></SideMenu>
-        </nav>
-        <main id="main" ref="main" class="twelve wide column">
-            <nav v-if="$route.meta.urls" class="ui breadcrumb">
-                <span v-for="url in $route.meta.urls" :key="url">
-                    <router-link :to="url.url" class="section">{{ url.title }}</router-link>
-                    <i class="right angle icon divider"></i>
-                </span>
-                <span class="active section">{{ $route.meta.title }}</span>
-            </nav>
-            <h1 class="ui header">
-                {{ $route.meta.title }}
-                <div class="sub header">
-                    {{ $route.meta.description }}
-                </div>
-            </h1>
-            <section class="mt-2 ui segment">
-                <router-view />
-            </section>
-            <loading
-            :active="$store.dispatch['loading/isLoad']" :can-cancel="false" :is-full-page="true" />
-        </main>
-    </div>
-</template>
-<script>
-export default {
-    data() {
-        return {
-            initHeight: 0,
-            sidebarHeight: 0,
-            mainHeight: 0,
-            isMounted: false,
-            urls:[]
-        };
-    },
-    components:{
-        Loading
-    },
-    computed: {
-        higherHeightPx() {
-            return this.isMounted
-                ? Math.max(this.sidebarHeight, this.mainHeight) + "px"
-                : null;
-        },
-        isLoading() {
-            return this.$store.dispatch('loading/isLoad');
-        }
-    },
-    watch: {
-        $route(to, from) {
-            this.$store.dispatch("clearCards");
-            this.$store.dispatch("clearMessage");
-            this.$store.dispatch("message/clear");
-            // 画面が替わる度に高さをリセット。
-            this.mainHeight = this.initHeight;
-        },
-    },
-    mounted: function () {
-        this.$store.dispatch("clearCards");
-        this.$store.dispatch("clearMessage");
+  <header>
+    <div class="ui pointing menu">
+      <div class="header navbar-brand">
+        <router-link to="/" class="navbar-brand">
+          <i class="bi bi-gem"></i> SPARKCARD
+        </router-link>
+      </div>
 
-        // メイン部分のリサイズ検知
-        const main = document.querySelector("#main");
-        if (!main) {
-            const resizeObserver = new ResizeObserver((entries) => {
-                this.mainHeight = this.$refs.main.clientHeight;
-            });
-            resizeObserver.observe(main);
-            this.sidebarHeight = this.$refs.sidebar.clientHeight;
-            this.mainHeight = this.$refs.main.clientHeight;
-            this.initHeight = this.mainHeight;
-            this.isMounted = true;
-        }
-    },
-};
-</script>
+      <div class="right menu">
+        <router-link
+          to="/config/expansion"
+          class="item"
+          :class="{ active: route.path === '/config/expansion' }"
+        >
+          <i class="cogs icon"></i>マスタ設定
+        </router-link>
+      </div>
+    </div>
+  </header>
+
+  <div id="contents" class="ui grid padded">
+    <nav
+      ref="sidebar"
+      class="three wide column blue"
+      :style="{ height: higherHeightPx }"
+    >
+      <SideMenu />
+    </nav>
+
+    <main id="main" ref="main" class="twelve wide column">
+      <nav v-if="route.meta.urls" class="ui breadcrumb">
+        <span v-for="url in route.meta.urls" :key="url">
+          <router-link :to="url.url" class="section">
+            {{ url.title }}
+          </router-link>
+          <i class="right angle icon divider"></i>
+        </span>
+        <span class="active section">{{ route.meta.title }}</span>
+      </nav>
+
+      <h1 class="ui header">
+        {{ route.meta.title }}
+        <div class="sub header">
+          {{ route.meta.description }}
+        </div>
+      </h1>
+
+      <section class="mt-2 ui segment">
+        <router-view />
+      </section>
+
+      <!-- ローディング -->
+      <Loading
+        :active="isLoading"
+        :can-cancel="false"
+        :is-full-page="true"
+      />
+    </main>
+  </div>
+</template>
+
 <style scoped>
 .ui.grid {
-    height: 100%;
-    min-height: 100%;
+  height: 100%;
+  min-height: 100%;
 }
+
 .ui.grid .blue.column {
-    margin-right: 3em;
-    padding-left: 0;
-    padding-right: 0;
-    background-color: #1e50a2 !important;
-    height: 100vh;
-    padding-top: 0;
+  margin-right: 3em;
+  padding-left: 0;
+  padding-right: 0;
+  background-color: #1e50a2 !important;
+  height: 100vh;
+  padding-top: 0;
 }
 
 #contents {
-    background-color: whitesmoke;
+  background-color: whitesmoke;
 }
 </style>

--- a/resources/js/pages/baseshop/BaseApiIntegration.vue
+++ b/resources/js/pages/baseshop/BaseApiIntegration.vue
@@ -10,6 +10,8 @@ const router = useRouter();
 const route = useRoute();
 const isLoading = ref(false);
 const authUrl = ref("");
+const code = ref("");
+const error = ref("");
 
 const toAuthServer = async() => {
     isLoading.value = true;
@@ -25,11 +27,25 @@ const toAuthServer = async() => {
             isLoading.value = false;
         });
 };
-const nextPage = () => {
-//    console.log(route.query.redirect);
-    const baseStore = baseConnected();
-    baseStore.connect();
-    router.push(route.query.redirect);
+const connect = async() => {
+    isLoading.value = true;
+    const query = {
+        code: code.value
+    };
+
+    await axios.post('/api/base/oauth/callback', query)
+        .then((response) => {
+            console.log(response.data);
+            const baseStore = baseConnected();
+            baseStore.connect();
+            router.push(route.query.redirect);
+        })
+        .catch((e) => {
+            error.value = e.response.data.detail;
+        })
+        .finally(() => {
+            isLoading.value = false;
+        });
 };
 </script>
 <template>
@@ -41,6 +57,11 @@ const nextPage = () => {
                     <div class="sub header">BASE APIと連携するために認可コードを設定します。</div>
                 </div>
             </h1>
+            <div class="ui negative message" v-if="error">
+                <div class="header">
+                    {{ error }}
+                </div>
+            </div>
             <section>
                 <h3 class="mt-2 ui top attached header aligned left">
                     認可コードの取得方法
@@ -56,11 +77,11 @@ const nextPage = () => {
                     <div class="ui seven column form">
                         <div class="field required">
                             <label>認可コード</label>
-                            <input type="text" name="auth-code">
+                            <input type="text" name="auth-code" v-model="code">
                         </div>
 
                         <div class="ui center aligned">
-                        <button class="ui teal button" @click="nextPage">
+                        <button class="ui teal button" @click="connect">
                             <i class="linkify icon"></i>
                             連携する
                         </button>
@@ -80,6 +101,10 @@ const nextPage = () => {
 </template>
 <style scoped>
 .ui.header .content {
+    text-align: left;
+}
+
+.negative .message > header {
     text-align: left;
 }
 

--- a/resources/js/pages/stockpile/StockpilePage.vue
+++ b/resources/js/pages/stockpile/StockpilePage.vue
@@ -67,13 +67,13 @@ export default {
     <message-area/>
     <article class="mt-1 ui form segment">
         <div class="two fields">
-            <div class="five wide field">
+            <div class="four wide field">
                 <label>カード名(一部)</label>
                 <input v-model="cardname" type="text">
             </div>
 
-            <div class="four wide field">
-                <label for="">セット名(ex:ローウィン)</label>
+            <div class="three wide field">
+                <label for="">セット略称(ex:LRW)</label>
                 <div class="ui input">
                     <input v-model="setname" type="text">
                 </div>
@@ -114,7 +114,7 @@ export default {
                     <td>{{ s.id }}</td>
                     <td>
                             <h4 class="ui image header">
-                                <img    
+                                <img
                                 :src="s.card.image_url"
                                 class="ui mini rounded image"
                                 @click="$refs.modal[index].showImage(s.id)"

--- a/resources/js/stores/auth/baseConnected.js
+++ b/resources/js/stores/auth/baseConnected.js
@@ -16,10 +16,20 @@ export const baseConnected = defineStore('baseConnected', () => {
         expiresAt.value = null;
     }
 
+    function hasConnected() {
+        if (!isConnected.value || !expiresAt.value) {
+            return false;
+        }
+        const now = new Date();
+        const diff = now.getTime() - expiresAt.value.getTime();
+        return isConnected.value = true && Math.abs(diff) / (60 * 1000) < 60; // 1時間以内であれば接続状態を維持
+    }
+
     return {
         isConnected,
         expiresAt,
         connect,
-        disconnect
+        disconnect,
+        hasConnected
     };
 });

--- a/resources/js/stores/loading/Loading.js
+++ b/resources/js/stores/loading/Loading.js
@@ -1,6 +1,6 @@
 import {ref} from 'vue';
 import {defineStore} from 'pinia';
-export const useLoadingStore = defineStore('useLoadingStore', () => {
+export const LoadingStore = defineStore('LoadingStore', () => {
     const isLoading = ref(false);
 
     // Loading画面を表示する。
@@ -11,5 +11,6 @@ export const useLoadingStore = defineStore('useLoadingStore', () => {
     function stop() {
         isLoading.value = false;
     }
-    return {isLoading, start, stop}
-}
+
+    return {start, stop, isLoading};
+});

--- a/tests/Unit/Auth/BaseOAuthTest.php
+++ b/tests/Unit/Auth/BaseOAuthTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\tests\Unit\Auth;
 use App\Exceptions\api\Baseshop\BaseApiException;
 use App\Models\BaseToken;
 use App\Repositories\Api\Baseshop\BaseApiRepository;
+use App\Repositories\Api\Baseshop\BaseOAuthRepository;
 use Carbon\CarbonImmutable;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\DB;
@@ -51,7 +52,7 @@ class BaseOAuthTest extends TestCase
             BCon::REFRESH_TOKEN => Uuid::uuid4()->toString(),
             BCon::EXPIRES_IN => 3600];
 
-        $this->mockRepository($code, $exToken);
+        $this->mockRepository('getAccessToken', $code, $exToken);
         $params = ['code' => $code];
         $response = $this->post('/api/base/oauth/callback', $params);
         $response->assertStatus(Response::HTTP_CREATED);
@@ -76,13 +77,13 @@ class BaseOAuthTest extends TestCase
         ];
 
         $params = ['code' => $code];
-        $mock = Mockery::mock(BaseApiRepository::class)->makePartial();
+        $mock = Mockery::mock(BaseOAuthRepository::class)->makePartial();
         $mock->shouldReceive('getAccessToken')
             ->once()
             ->with($code)
             ->andThrow(new BaseApiException(json_encode($exToken)));
 
-        $this->app->instance(BaseApiRepository::class, $mock);
+        $this->app->instance(BaseOAuthRepository::class, $mock);
         $response = $this->post('/api/base/oauth/callback', $params);
         $response->assertStatus(Response::HTTP_BAD_REQUEST);
     }
@@ -95,14 +96,14 @@ class BaseOAuthTest extends TestCase
         $response->assertJsonPath(BCon::CONNECTED, true);
     }
 
-    private function mockRepository($code, $exToken)
+    private function mockRepository($method, $code, $exToken)
     {
-        $mock = Mockery::mock(BaseApiRepository::class)->makePartial();
-        $mock->shouldReceive('getAccessToken')
+        $mock = Mockery::mock(BaseOAuthRepository::class)->makePartial();
+        $mock->shouldReceive($method)
             ->once()
             ->with($code)
             ->andReturn($exToken);
 
-        $this->app->instance(BaseApiRepository::class, $mock);
+        $this->app->instance(BaseOAuthRepository::class, $mock);
     }
 }

--- a/tests/Unit/Auth/BaseOAuthTest.php
+++ b/tests/Unit/Auth/BaseOAuthTest.php
@@ -55,13 +55,7 @@ class BaseOAuthTest extends TestCase
         $response->assertStatus(Response::HTTP_CREATED);
         $response->assertJsonPath(BCon::CONNECTED, true);
 
-        $this->assertEquals(1, BaseToken::all()->count());
-        $token = BaseToken::first();
-        $this->assertEquals($exToken[BCon::ACCESS_TOKEN], $token->access_token);
-        $this->assertEquals($exToken[BCon::REFRESH_TOKEN], $token->refresh_token);
-
-        $diff  = $token->expires_in->diffInSeconds(CarbonImmutable::now()->addHour());
-        $this->assertLessThanOrEqual(5, $diff); // 5秒以内の誤差を許容
+        $this->verifyToken($exToken);
     }
 
     #[Test]
@@ -90,22 +84,23 @@ class BaseOAuthTest extends TestCase
     #[TestDox('status:アクセストークンが有効期限内なら「連携済み」')]
     public function ok_status_exp() {
         $extoken = $this->createRandomToken();
-        BaseToken::create([
-            BCon::ACCESS_TOKEN => $extoken[BCon::ACCESS_TOKEN],
-            BCon::REFRESH_TOKEN => $extoken[BCon::REFRESH_TOKEN],
-            BCon::EXPIRES_IN => now()->addSeconds($extoken[BCon::EXPIRES_IN])
-        ]);
+        $this->saveBaseToken($extoken);
 
-        $response = $this->get('/api/base/oauth/status');
-        $response->assertStatus(Response::HTTP_OK);
-        $response->assertJsonPath(BCon::CONNECTED, true);
+        $this->executeStatusTest(true);
     }
 
     #[Test]
     #[Group('status')]
     #[TestDox('status:アクセストークンが有効期限切れなら再発行した上で「連携済み」')]
     public function ok_status_expired() {
+        $expiredToken = $this->createRandomToken();
+        $this->saveBaseToken($expiredToken, -3660); // 有効期限を1時間1分前に設定
 
+        $exToken = $this->createRandomToken();
+        $this->mockRepository('refreshAccessToken', $expiredToken[BCon::REFRESH_TOKEN], $exToken);
+
+        $this->executeStatusTest(true);
+        $this->verifyToken($exToken);
     }
 
     #[Test]
@@ -128,6 +123,35 @@ class BaseOAuthTest extends TestCase
 
     }
 
+    /**
+     * エンドポイントが'/api/base/oauth/status'のレスポンスを
+     * 検証する。
+     *
+     * @param boolean $isConnected
+     * @return void
+     */
+    private function executeStatusTest(bool $isConnected) {
+        $response = $this->get('/api/base/oauth/status');
+        $response->assertStatus(Response::HTTP_OK);
+        $response->assertJsonPath(BCon::CONNECTED, $isConnected);
+
+    }
+
+    /**
+     * base_tokenテーブルにレコードを1件登録する。
+     *
+     * @param array $extoken ランダムなアクセストークン情報
+     * @param integer $expiresIn アクセストークンの有効期限（秒）
+     * @return void
+     */
+    private function saveBaseToken(array $extoken, int $expiresIn = 3600) {
+        BaseToken::create([
+            BCon::ACCESS_TOKEN => $extoken[BCon::ACCESS_TOKEN],
+            BCon::REFRESH_TOKEN => $extoken[BCon::REFRESH_TOKEN],
+            BCon::EXPIRES_IN => now()->addSeconds($expiresIn)
+        ]);
+    }
+
     private function mockRepository($method, $code, $exToken)
     {
         $mock = Mockery::mock(BaseOAuthRepository::class)->makePartial();
@@ -138,6 +162,23 @@ class BaseOAuthTest extends TestCase
 
         $this->app->instance(BaseOAuthRepository::class, $mock);
     }
+
+    /**
+     * base_tokenテーブルのレコードを検証する。
+     *
+     * @param array $exToken
+     * @return void
+     */
+    private function verifyToken(array $exToken) {
+        $this->assertEquals(1, BaseToken::all()->count());
+        $token = BaseToken::first();
+        $this->assertEquals($exToken[BCon::ACCESS_TOKEN], $token->access_token);
+        $this->assertEquals($exToken[BCon::REFRESH_TOKEN], $token->refresh_token);
+
+        $diff  = $token->expires_in->diffInSeconds(CarbonImmutable::now()->addHour());
+        $this->assertLessThanOrEqual(5, $diff); // 5秒以内の誤差を許容
+    }
+
 
     /**
      * テスト用のトークンをランダムに生成する。

--- a/tests/Unit/Auth/BaseOAuthTest.php
+++ b/tests/Unit/Auth/BaseOAuthTest.php
@@ -4,7 +4,6 @@ namespace Tests\Feature\tests\Unit\Auth;
 
 use App\Exceptions\api\Baseshop\BaseApiException;
 use App\Models\BaseToken;
-use App\Repositories\Api\Baseshop\BaseApiRepository;
 use App\Repositories\Api\Baseshop\BaseOAuthRepository;
 use Carbon\CarbonImmutable;
 use Illuminate\Http\Response;
@@ -107,20 +106,31 @@ class BaseOAuthTest extends TestCase
     #[Group('status')]
     #[TestDox('status:アクセストークンが未登録なら「未連携」')]
     public function ng_status_no_token() {
-
+        $this->executeStatusTest(false);
     }
 
     #[Test]
     #[Group('status')]
-    #[TestDox('status:リフレッシュトークンが有効期限切れなら「未連携」')]
+    #[TestDox('status:BASE APIのトークン再発行に失敗した場合、HTTPステータスコード「400」とエラーメッセージを返す。')]
     public function ng_status_expired_refresh_token() {
+        $exError = [
+            'error' => 'invalid_request',
+            'error_description' => 'リフレッシュトークンの有効期限が切れています。'
+        ];
 
-    }
+        $extoken = $this->createRandomToken();
+        $this->saveBaseToken($extoken, -5000);
 
-    #[Test]
-    #[TestDox('再発行に失敗した場合、「未連携」と判断するテスト')]
-    public function ng_status_faiure_refresh() {
+        $mock = Mockery::mock(BaseOAuthRepository::class)->makePartial();
+        $mock->shouldReceive('refreshAccessToken')
+            ->once()
+            ->with($extoken[BCon::REFRESH_TOKEN])
+            ->andThrow(new BaseApiException(json_encode($exError)));
 
+        $this->app->instance(BaseOAuthRepository::class, $mock);
+        $response = $this->get('/api/base/oauth/status');
+        $response->assertStatus(Response::HTTP_BAD_REQUEST);
+        $response->assertJsonPath('detail', $exError['error_description']);
     }
 
     /**

--- a/tests/Unit/Auth/BaseOAuthTest.php
+++ b/tests/Unit/Auth/BaseOAuthTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\Attributes\TestDox;
 use Ramsey\Uuid\Uuid;
 use Tests\TestCase;
 use App\Services\Constant\BaseApiConstant as BCon;
+use PHPUnit\Framework\Attributes\Group;
 
 #[TestDox('BASE APIの認証関連のテスト')]
 #[CoversClass(BaseOAuthController::class)]
@@ -46,11 +47,7 @@ class BaseOAuthTest extends TestCase
     public function ok_callback(): void
     {
         $code = 'test_code';
-        $exToken = [
-            BCon::ACCESS_TOKEN => Uuid::uuid4()->toString(),
-            'token_type' => 'bearer',
-            BCon::REFRESH_TOKEN => Uuid::uuid4()->toString(),
-            BCon::EXPIRES_IN => 3600];
+        $exToken = $this->createRandomToken();
 
         $this->mockRepository('getAccessToken', $code, $exToken);
         $params = ['code' => $code];
@@ -89,11 +86,46 @@ class BaseOAuthTest extends TestCase
     }
 
     #[Test]
-    #[TestDox('BASE APIの連携ステータスがOKか確認する。')]
-    public function ok_status() {
+    #[Group('status')]
+    #[TestDox('status:アクセストークンが有効期限内なら「連携済み」')]
+    public function ok_status_exp() {
+        $extoken = $this->createRandomToken();
+        BaseToken::create([
+            BCon::ACCESS_TOKEN => $extoken[BCon::ACCESS_TOKEN],
+            BCon::REFRESH_TOKEN => $extoken[BCon::REFRESH_TOKEN],
+            BCon::EXPIRES_IN => now()->addSeconds($extoken[BCon::EXPIRES_IN])
+        ]);
+
         $response = $this->get('/api/base/oauth/status');
         $response->assertStatus(Response::HTTP_OK);
         $response->assertJsonPath(BCon::CONNECTED, true);
+    }
+
+    #[Test]
+    #[Group('status')]
+    #[TestDox('status:アクセストークンが有効期限切れなら再発行した上で「連携済み」')]
+    public function ok_status_expired() {
+
+    }
+
+    #[Test]
+    #[Group('status')]
+    #[TestDox('status:アクセストークンが未登録なら「未連携」')]
+    public function ng_status_no_token() {
+
+    }
+
+    #[Test]
+    #[Group('status')]
+    #[TestDox('status:リフレッシュトークンが有効期限切れなら「未連携」')]
+    public function ng_status_expired_refresh_token() {
+
+    }
+
+    #[Test]
+    #[TestDox('再発行に失敗した場合、「未連携」と判断するテスト')]
+    public function ng_status_faiure_refresh() {
+
     }
 
     private function mockRepository($method, $code, $exToken)
@@ -105,5 +137,20 @@ class BaseOAuthTest extends TestCase
             ->andReturn($exToken);
 
         $this->app->instance(BaseOAuthRepository::class, $mock);
+    }
+
+    /**
+     * テスト用のトークンをランダムに生成する。
+     *
+     * @return array
+     */
+    private function createRandomToken():array {
+        $exToken = [
+                BCon::ACCESS_TOKEN => Uuid::uuid4()->toString(),
+                'token_type' => 'bearer',
+                BCon::REFRESH_TOKEN => Uuid::uuid4()->toString(),
+                BCon::EXPIRES_IN => 3600
+        ];
+        return $exToken;
     }
 }

--- a/tests/Unit/Auth/BaseOAuthTest.php
+++ b/tests/Unit/Auth/BaseOAuthTest.php
@@ -6,16 +6,15 @@ use App\Exceptions\api\Baseshop\BaseApiException;
 use App\Models\BaseToken;
 use App\Repositories\Api\Baseshop\BaseApiRepository;
 use Carbon\CarbonImmutable;
-use GuzzleHttp\Exception\RequestException;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Http;
 use Mockery;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\TestDox;
 use Ramsey\Uuid\Uuid;
 use Tests\TestCase;
+use App\Services\Constant\BaseApiConstant as BCon;
 
 #[TestDox('BASE APIの認証関連のテスト')]
 #[CoversClass(BaseOAuthController::class)]
@@ -47,23 +46,23 @@ class BaseOAuthTest extends TestCase
     {
         $code = 'test_code';
         $exToken = [
-                'access_token' => Uuid::uuid4()->toString(),
-                'token_type' => 'bearer',
-                'refresh_token' => Uuid::uuid4()->toString(),
-                'expires_in' => 3600];
+            BCon::ACCESS_TOKEN => Uuid::uuid4()->toString(),
+            'token_type' => 'bearer',
+            BCon::REFRESH_TOKEN => Uuid::uuid4()->toString(),
+            BCon::EXPIRES_IN => 3600];
 
         $this->mockRepository($code, $exToken);
         $params = ['code' => $code];
         $response = $this->post('/api/base/oauth/callback', $params);
         $response->assertStatus(Response::HTTP_CREATED);
-        $response->assertJsonPath('connected', true);
+        $response->assertJsonPath(BCon::CONNECTED, true);
 
         $this->assertEquals(1, BaseToken::all()->count());
         $token = BaseToken::first();
-        $this->assertEquals($exToken['access_token'], $token->access_token);
-        $this->assertEquals($exToken['refresh_token'], $token->refresh_token);
+        $this->assertEquals($exToken[BCon::ACCESS_TOKEN], $token->access_token);
+        $this->assertEquals($exToken[BCon::REFRESH_TOKEN], $token->refresh_token);
 
-        $diff  = $token->expires_at->diffInSeconds(CarbonImmutable::now()->addHour());
+        $diff  = $token->expires_in->diffInSeconds(CarbonImmutable::now()->addHour());
         $this->assertLessThanOrEqual(5, $diff); // 5秒以内の誤差を許容
     }
 
@@ -86,7 +85,14 @@ class BaseOAuthTest extends TestCase
         $this->app->instance(BaseApiRepository::class, $mock);
         $response = $this->post('/api/base/oauth/callback', $params);
         $response->assertStatus(Response::HTTP_BAD_REQUEST);
+    }
 
+    #[Test]
+    #[TestDox('BASE APIの連携ステータスがOKか確認する。')]
+    public function ok_status() {
+        $response = $this->get('/api/base/oauth/status');
+        $response->assertStatus(Response::HTTP_OK);
+        $response->assertJsonPath(BCon::CONNECTED, true);
     }
 
     private function mockRepository($code, $exToken)


### PR DESCRIPTION
## 概要

BASE APIの連携ステータスを確認するAPIを実装し、Vue側と連携しました。

## 変更点

- BASE APIと本アプリが「連携済み」か「未連携」か確認するAPIを実装しました。
- Vue側からBASE API機能を使用する場合、自動で連携ステータスを取得する機能を実装しました。

## 影響範囲

なし。

## ユニットテスト

- BaseOauthTest.php

## 関連Issue
なし。

fix #289 